### PR TITLE
Issue_68: Moved modules out of setup.py to requirements.txt for more …

### DIFF
--- a/Python/dawgie/db/post.py
+++ b/Python/dawgie/db/post.py
@@ -765,7 +765,7 @@ def archive (done):
             '-d', dawgie.context.db_name,
             '-f', os.path.join (path, bfn.format (0))]
     handler = ArchiveHandler(' '.join (args), done)
-    twisted.internet.reactor.spawnProcess (handler, args[0], args=args)
+    twisted.internet.reactor.spawnProcess (handler, args[0], args=args, env=os.environ)
     return
 
 def close(): return

--- a/Python/dawgie/db/post.py
+++ b/Python/dawgie/db/post.py
@@ -752,7 +752,7 @@ def archive (done):
         raise ValueError('The path "' + path +
                          '" does not exist or is not a directory')
 
-    for i in range (19,0,-1):
+    for i in range (int(dawgie.context.db_rotate)-1,0,-1):
         ffn = os.path.join (path, bfn.format (i-1))
         nfn = os.path.join (path, bfn.format (i))
 

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,0 +1,13 @@
+bokeh>=1.2
+boto3>=1.7.80
+cryptography>=2.1.4
+dawgie-pydot3==1.0.10
+GitPython>=2.1.11
+matplotlib>=2.1.1
+psycopg2-binary>=2.7.4
+pyparsing>=2.2
+python-gnupg==0.4.4
+pyxb==1.2.6
+requests>=2.20.0
+transitions==0.6.8
+twisted>=18.7.0

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -39,8 +39,6 @@ NTR:
 '''
 
 import os
-from pathlib import Path
-import re
 import setuptools
 
 
@@ -48,39 +46,29 @@ def read_requirements():
     requirements = []
     with open('./requirements.txt', 'r') as file:
         for line in file:
-            # exclude comments
-            if re.match('^\\s*#.*', line):
-                # print('****************LINE--', line)
-                continue
-            requirements.append(str(line.lstrip().rstrip()))
+            line = str(line)  # guard against str exceptions
+            line = line[:line.find("#")] if "#" in line else line  # exclude comments
+            line = line.strip()  # clean
+            if line:
+                requirements.append(line)
     return requirements
 
 
 dawgie = os.path.join ('dawgie', '__init__.py')
 version = os.environ.get ('DAWGIE_VERSION', '0.0.0')
-with open (os.path.join (os.path.dirname (__file__), dawgie)) as f: t = f.read()
+with open (os.path.join (os.path.dirname (__file__), dawgie)) as f:
+    t = f.read()
 t = t.replace ("'0.0.0'", "'{0}'".format (version))
-with open (os.path.join (os.path.dirname (__file__), dawgie), 'tw') as f:\
-     f.write (t)
+with open (os.path.join (os.path.dirname (__file__), dawgie), 'tw') as f:
+    f.write(t)
 
-data_files_locations = []
-
-read_me_file_dir_string = "."
-read_me_file = Path(__file__).absolute().parent / "README.md"
-if read_me_file.exists() is False:
-    read_me_file_dir_string = ".."
-    read_me_file = read_me_file.parent.parent / read_me_file.name
-data_files_locations.append((".", [read_me_file_dir_string + "/" + read_me_file.name]))
-
-license_file_dir_string = "."
-license_file = Path(__file__).absolute().parent / "LICENSE.txt"
-if license_file.exists() is False:
-    license_file_dir_string = ".."
-    license_file = license_file.parent.parent / license_file.name
-data_files_locations.append((".", [license_file_dir_string + "/" + license_file.name]))
-
-with read_me_file.open() as f:
+read_me_file_name = "README.md"
+read_me_file = read_me_file_name if os.path.exists(read_me_file_name) else f"../{read_me_file_name}"
+with open(read_me_file, "rt") as f:
     description = f.read()
+
+data_files_names = [read_me_file_name, "LICENSE.txt"]
+data_files_locations = [('.', [f]) if os.path.exists(f) else ('.', ["../" + f]) for f in data_files_names]
 
 deps = read_requirements()
 setuptools.setup (name='dawgie',

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -39,31 +39,50 @@ NTR:
 '''
 
 import os
+from pathlib import Path
+import re
 import setuptools
 
+
+def read_requirements():
+    requirements = []
+    with open('./requirements.txt', 'r') as file:
+        for line in file:
+            # exclude comments
+            if re.match('^\\s*#.*', line):
+                # print('****************LINE--', line)
+                continue
+            requirements.append(str(line.lstrip().rstrip()))
+    return requirements
+
+
 dawgie = os.path.join ('dawgie', '__init__.py')
-deps = ['bokeh>=1.2',
-        'boto3>=1.7.80',
-        'cryptography>=2.1.4',
-        'dawgie-pydot3==1.0.10',
-        'GitPython>=2.1.11',
-        'matplotlib>=2.1.1',
-        'psycopg2>=2.7.4',
-        'pyparsing>=2.2',
-        'python-gnupg==0.4.4',
-        'pyxb==1.2.6',
-        'requests>=2.20.0',
-        'transitions==0.6.8',
-        'twisted>=18.7.0',
-        ]
 version = os.environ.get ('DAWGIE_VERSION', '0.0.0')
 with open (os.path.join (os.path.dirname (__file__), dawgie)) as f: t = f.read()
 t = t.replace ("'0.0.0'", "'{0}'".format (version))
 with open (os.path.join (os.path.dirname (__file__), dawgie), 'tw') as f:\
      f.write (t)
-with open (os.path.join (os.path.dirname (__file__), 'README.md'), 'rt') as f:\
-     description = f.read()
 
+data_files_locations = []
+
+read_me_file_dir_string = "."
+read_me_file = Path(__file__).absolute().parent / "README.md"
+if read_me_file.exists() is False:
+    read_me_file_dir_string = ".."
+    read_me_file = read_me_file.parent.parent / read_me_file.name
+data_files_locations.append((".", [read_me_file_dir_string + "/" + read_me_file.name]))
+
+license_file_dir_string = "."
+license_file = Path(__file__).absolute().parent / "LICENSE.txt"
+if license_file.exists() is False:
+    license_file_dir_string = ".."
+    license_file = license_file.parent.parent / license_file.name
+data_files_locations.append((".", [license_file_dir_string + "/" + license_file.name]))
+
+with read_me_file.open() as f:
+    description = f.read()
+
+deps = read_requirements()
 setuptools.setup (name='dawgie',
                   version=version,
                   packages=['dawgie',
@@ -105,7 +124,7 @@ setuptools.setup (name='dawgie',
                                "Operating System :: OS Independent",
                                'License :: Free To Use But Restricted',
                                'Development Status :: 5 - Production/Stable'],
-                  data_files=[('.', ['LICENSE', 'README.md'])],
+                  data_files=data_files_locations,
                   description='Data and Algorithm Work-flow Generation, Introspection, and Execution (DAWGIE)',
                   license='see LICENSE file for details',
                   long_description=description,

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -56,18 +56,18 @@ def read_requirements():
     return requirements
 
 
-dawgie = os.path.join ('dawgie', '__init__.py')
-version = os.environ.get ('DAWGIE_VERSION', '0.0.0')
-with open (os.path.join (os.path.dirname (__file__), dawgie)) as f:
+dawgie = os.path.join('dawgie', '__init__.py')
+version = os.environ.get('DAWGIE_VERSION', '0.0.0')
+with open(os.path.join(os.path.dirname(__file__), dawgie)) as f:
     t = f.read()
-t = t.replace ("'0.0.0'", "'{0}'".format (version))
-with open (os.path.join (os.path.dirname (__file__), dawgie), 'tw') as f:
+t = t.replace("'0.0.0'", "'{0}'".format(version))
+with open(os.path.join(os.path.dirname(__file__), dawgie), 'tw') as f:
     f.write(t)
 
 # first item in list must be README file name
 data_files_names = ["README.md", "LICENSE.txt"]
 data_files_locations = [('.', [f]) if os.path.exists(f) else
-    ('.', ["../" + f]) for f in data_files_names]
+                        ('.', ["../" + f]) for f in data_files_names]
 
 read_me_file = data_files_names[0] if os.path.exists(data_files_names[0]) else \
     f"../{data_files_names[0]}"
@@ -75,19 +75,21 @@ with open(read_me_file, "rt") as f:
     description = f.read()
 
 deps = read_requirements()
-setuptools.setup (name='dawgie',
-                  version=version,
-                  packages=['dawgie',
-                            'dawgie.db', 'dawgie.db.tools',
-                            'dawgie.de',
-                            'dawgie.fe',
-                            'dawgie.pl', 'dawgie.pl.logger',
-                            'dawgie.tools'],
-                  setup_requires=deps,
-                  src_root=os.path.abspath (os.path.dirname (__file__)),
-                  install_requires=deps,
-                  package_data={'dawgie.pl':['state.dot'],
-                                'dawgie.fe':['fonts/open*','fonts/bootstrap/*',
+setuptools.setup(name='dawgie',
+                 version=version,
+                 packages=['dawgie',
+                           'dawgie.db',
+                           'dawgie.db.tools',
+                           'dawgie.de',
+                           'dawgie.fe',
+                           'dawgie.pl',
+                           'dawgie.pl.logger',
+                           'dawgie.tools'],
+                 setup_requires=deps,
+                 src_root=os.path.abspath(os.path.dirname(__file__)),
+                 install_requires=deps,
+                 package_data={'dawgie.pl': ['state.dot'],
+                               'dawgie.fe': ['fonts/open*', 'fonts/bootstrap/*',
                                              'images/*.jpg',
                                              'images/*.gif',
                                              'images/svg/*',
@@ -110,16 +112,16 @@ setuptools.setup (name='dawgie',
                                              'pages/search/index.html',
                                              'pages/tasks/index.html',
                                              'stylesheets/*.css']},
-                  author='Al Niessner',
-                  author_email='Al.Niessner@jpl.nasa.gov',
-                  classifiers=["Programming Language :: Python :: 3",
-                               "Operating System :: OS Independent",
-                               'License :: Free To Use But Restricted',
-                               'Development Status :: 5 - Production/Stable'],
-                  data_files=data_files_locations,
-                  description='Data and Algorithm Work-flow Generation, Introspection, and Execution (DAWGIE)',
-                  license='see LICENSE file for details',
-                  long_description=description,
-                  long_description_content_type="text/markdown",
-                  keywords='adaptive pipeline',
-                  url='https://github.com/al-niessner/DAWGIE')
+                 author='Al Niessner',
+                 author_email='Al.Niessner@jpl.nasa.gov',
+                 classifiers=["Programming Language :: Python :: 3",
+                              "Operating System :: OS Independent",
+                              'License :: Free To Use But Restricted',
+                              'Development Status :: 5 - Production/Stable'],
+                 data_files=data_files_locations,
+                 description='Data and Algorithm Work-flow Generation, Introspection, and Execution (DAWGIE)',
+                 license='see LICENSE file for details',
+                 long_description=description,
+                 long_description_content_type="text/markdown",
+                 keywords='adaptive pipeline',
+                 url='https://github.com/al-niessner/DAWGIE')

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -39,16 +39,18 @@ NTR:
 '''
 
 import os
+
 import setuptools
 
 
 def read_requirements():
     requirements = []
-    with open('./requirements.txt', 'r') as file:
+    with open('./requirements.txt', 'rt') as file:
         for line in file:
-            line = str(line)  # guard against str exceptions
-            line = line[:line.find("#")] if "#" in line else line  # exclude comments
-            line = line.strip()  # clean
+            # exclude comments
+            line = line[:line.find("#")] if "#" in line else line
+            # clean
+            line = line.strip()
             if line:
                 requirements.append(line)
     return requirements
@@ -62,13 +64,15 @@ t = t.replace ("'0.0.0'", "'{0}'".format (version))
 with open (os.path.join (os.path.dirname (__file__), dawgie), 'tw') as f:
     f.write(t)
 
-read_me_file_name = "README.md"
-read_me_file = read_me_file_name if os.path.exists(read_me_file_name) else f"../{read_me_file_name}"
+# first item in list must be README file name
+data_files_names = ["README.md", "LICENSE.txt"]
+data_files_locations = [('.', [f]) if os.path.exists(f) else
+    ('.', ["../" + f]) for f in data_files_names]
+
+read_me_file = data_files_names[0] if os.path.exists(data_files_names[0]) else \
+    f"../{data_files_names[0]}"
 with open(read_me_file, "rt") as f:
     description = f.read()
-
-data_files_names = [read_me_file_name, "LICENSE.txt"]
-data_files_locations = [('.', [f]) if os.path.exists(f) else ('.', ["../" + f]) for f in data_files_names]
 
 deps = read_requirements()
 setuptools.setup (name='dawgie',


### PR DESCRIPTION
…flexibility. Added method to read in from requirements.txt and feed into setup.py to improve installation flexibility. Fixed error reading README.md when it did not exist in setup directory. Fixed error locating LICENSE.txt due to pathing/naming. Converted file read into Pathlib operation. Converted psycopg2 to install via psycopg2-binary and tested, removing dependency on localized compilers.