### PR TITLE
issue_69: Updated GNUPG cleanup method to ignored failed deletes (e.g…

### DIFF
--- a/Python/dawgie/security.py
+++ b/Python/dawgie/security.py
@@ -210,13 +210,15 @@ def connect (address:(str, int))->socket.socket:
 def delete (keys:[str])->None: _pgp.delete_keys ('\n'.join (keys))
 def extend (keys:[str])->None: return _pgp.import_keys ('\n'.join (keys))
 
+
 def finalize()->None:
     '''clean up after ones self
 
     Should be called when all done with the security module.
     '''
-    shutil.rmtree (getattr (_pgp, gpgargname))
+    shutil.rmtree(getattr(_pgp, gpgargname), ignore_errors=True)
     return
+
 
 def initialize (path:str=None)->None:
     '''initialize this library with the PGP keyring location

--- a/Python/dawgie/security.py
+++ b/Python/dawgie/security.py
@@ -210,7 +210,6 @@ def connect (address:(str, int))->socket.socket:
 def delete (keys:[str])->None: _pgp.delete_keys ('\n'.join (keys))
 def extend (keys:[str])->None: return _pgp.import_keys ('\n'.join (keys))
 
-
 def finalize()->None:
     '''clean up after ones self
 
@@ -218,7 +217,6 @@ def finalize()->None:
     '''
     shutil.rmtree(getattr(_pgp, gpgargname), ignore_errors=True)
     return
-
 
 def initialize (path:str=None)->None:
     '''initialize this library with the PGP keyring location


### PR DESCRIPTION
…. file does not exist) to compensate for GNU PGP2 creating an intermittent concurrency issue when it cleans up the file itself during the call.