### PR TITLE
issue 113: aws testing

### DIFF
--- a/Test/test_02.py
+++ b/Test/test_02.py
@@ -54,7 +54,6 @@ import unittest
 
 class AWS(unittest.TestCase):
     failed = False
-    @unittest.skip ('changes in dawgie.pl.DeferLogException')
     def test_handshake (self):
         global _https_in,_https_out,_sqs_in,_sqs_out
         kdir = tempfile.mkdtemp()


### PR DESCRIPTION
Closes #113 

The problem was a bad dawgie.pl.LogDeferredException implementation. That was fixed in issue_111 and now this is back to working.