### PR TITLE
add version information (#125)

### DIFF
--- a/Python/dawgie/pl/farm.py
+++ b/Python/dawgie/pl/farm.py
@@ -75,7 +75,9 @@ class Hand(twisted.internet.protocol.Protocol):
             if msg.revision != dawgie.context.git_rev or \
                    not dawgie.pl.start.fsm.is_pipeline_active():
                 dawgie.pl.message.send (self._abort, self)
-                log.warning ('Worker and pipeline revisions are not the same.')
+                log.warning ('Worker and pipeline revisions are not the same. '+
+                             'Sever version %s and worker version %s.',
+                             str(msg.revision), str(dawgie.context.git_rev))
             else: dawgie.pl.message.send (self.__proceed, self)
             self.transport.loseConnection()
         else:


### PR DESCRIPTION
* add version information

Make sure that the versions are always strings by forcing them that way so that the log does not error because of the %s in the log message.

Upgraded test_10 to verify that the log message is correct.