### PR TITLE
Issue 139: implement promotion engine

### DIFF
--- a/.ci/Dockerfile.ap
+++ b/.ci/Dockerfile.ap
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.ap
+++ b/.ci/Dockerfile.ap
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2019, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.cit
+++ b/.ci/Dockerfile.cit
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.cit
+++ b/.ci/Dockerfile.cit
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.cit
+++ b/.ci/Dockerfile.cit
@@ -36,11 +36,11 @@
 
 FROM py:ghrVersion
 RUN set -ex && \
-    /usr/bin/pip3 install astroid==1.5.3 \
-                          coverage==4.4.1 \
-                          pycodestyle==2.4.0 \
-                          pylint==1.7.2 \
-                          pytest==3.1.3 \
-                          pytest-cov==2.5.1 \
-                          scipy==1.1.0 && \
+    /usr/bin/pip3 install astroid>=2.2.5 \
+                          coverage==4.5.3 \
+                          pycodestyle==2.5.0 \
+                          pylint==2.3.1 \
+                          pytest==4.4.2 \
+                          pytest-cov==2.7.1 \
+                          scipy>=1.1.0 && \
    rm -rf ${HOME}/.cache

--- a/.ci/Dockerfile.ex
+++ b/.ci/Dockerfile.ex
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.ex
+++ b/.ci/Dockerfile.ex
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2019, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.os
+++ b/.ci/Dockerfile.os
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.os
+++ b/.ci/Dockerfile.os
@@ -34,7 +34,7 @@
 #
 # NTR:
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN set -ex && \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
@@ -43,15 +43,11 @@ RUN set -ex && \
             graphviz \
             haveged \
             python3 \
-            python3-cryptography \
             python3-dev \
             python3-gdbm \
-            python3-levenshtein \
-            python3-matplotlib \
             python3-numpy \
             python3-pip \
             python3-psycopg2 \
-            python3-pyparsing \
             python3-setuptools && \
     apt-get clean && apt-get autoremove && \
     ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \

--- a/.ci/Dockerfile.os
+++ b/.ci/Dockerfile.os
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.py
+++ b/.ci/Dockerfile.py
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.py
+++ b/.ci/Dockerfile.py
@@ -1,5 +1,5 @@
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/Dockerfile.py
+++ b/.ci/Dockerfile.py
@@ -43,12 +43,12 @@ RUN set -ex && \
                  GitPython>=2.1.11 \
                  matplotlib>=2.1.1 \
                  psycopg2-binary>=2.7.4 \
-                 pyparsing>=2.2 \
+                 pyparsing==2.4.7 \
                  pyOpenSSL>=19.1.0 \
                  python-gnupg==0.4.4 \
                  pyxb==1.2.6 \
                  requests>=2.20.0 \
+                 service_identity \
                  transitions==0.6.8 \
                  twisted>=18.7.0  && \
-    cd /usr/local/lib/python3.6/dist-packages/pydot && \
     rm -rf ${HOME}/.cache /tmp/,ci

--- a/.ci/check_01.sh
+++ b/.ci/check_01.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/check_01.sh
+++ b/.ci/check_01.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/check_02.sh
+++ b/.ci/check_02.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/check_02.sh
+++ b/.ci/check_02.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/check_02.sh
+++ b/.ci/check_02.sh
@@ -55,16 +55,19 @@ count = 0
 rated = False
 with open ('pylint.rpt.txt', 'rt') as f:
     for l in f.readlines():
+        rated |= 0 < l.find ('code has been rated at')
+
         if l.startswith ('***'): mn = l.split()[2]
         if len (l) < 2: continue
         if l[0] not in 'CEFIRW' or l[1] != ':': continue
         if 0 < l.find ('(missing-docstring)'): continue
         if 0 < l.find ('(locally-disabled)'): continue
+
         count += 1
-        rated |= 0 < l.find ('code has been rated at')
         print (count, mn, l.strip())
         pass
     pass
+
 if 0 < count or not rated:
     print ('pylint check failed', count)
     with open ('.ci/status.txt', 'tw') as f: f.write ('failure')

--- a/.ci/check_02.sh
+++ b/.ci/check_02.sh
@@ -52,6 +52,7 @@ then
     python3 <<EOF
 mn = '<unknown>'
 count = 0
+rated = False
 with open ('pylint.rpt.txt', 'rt') as f:
     for l in f.readlines():
         if l.startswith ('***'): mn = l.split()[2]
@@ -60,10 +61,11 @@ with open ('pylint.rpt.txt', 'rt') as f:
         if 0 < l.find ('(missing-docstring)'): continue
         if 0 < l.find ('(locally-disabled)'): continue
         count += 1
+        rated |= 0 < l.find ('code has been rated at')
         print (count, mn, l.strip())
         pass
     pass
-if 0 < count:
+if 0 < count or not rated:
     print ('pylint check failed', count)
     with open ('.ci/status.txt', 'tw') as f: f.write ('failure')
 EOF

--- a/.ci/check_03.sh
+++ b/.ci/check_03.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/check_03.sh
+++ b/.ci/check_03.sh
@@ -48,7 +48,14 @@ post_state "$context" "$description" "$state"
 
 if current_state
 then
-    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" -v $PWD:$PWD -u $UID -w $PWD cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v Test | tee unittest.rpt.txt
+    if [[ $# -gt 0 ]]
+    then
+        units="$@"
+    else
+        units=Test
+    fi
+
+    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" -v $PWD:$PWD -u $UID -w $PWD cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
     [ 0 -lt `grep FAILED unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
     state=`get_state`
 fi

--- a/.ci/check_03.sh
+++ b/.ci/check_03.sh
@@ -57,6 +57,7 @@ then
 
     docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" -v $PWD:$PWD -u $UID -w $PWD cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
     [ 0 -lt `grep FAILED unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
+    [ 0 -lt `grep "ERROR at" unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
     state=`get_state`
 fi
 

--- a/.ci/check_03.sh
+++ b/.ci/check_03.sh
@@ -62,22 +62,22 @@ then
         docker pull postgres:latest
     fi
 
-    if [[ $(docker network inspect ${CIT_NETWORK:-bridge} | wc -l) -eq 1 ]]
+    if [[ $(docker network inspect ${CIT_NETWORK:-citnet} | wc -l) -eq 1 ]]
     then
-        echo "create the docker network: ${CIT_NETWORK:-bridge}"
-        docker network create ${CIT_NETWORK:-bridge}
+        echo "create the docker network: ${CIT_NETWORK:-citnet}"
+        docker network create ${CIT_NETWORK:-citnet}
     fi
 
     if [[ $(docker container inspect cit_postgres | wc -l) -eq 1 ]]
     then
         echo "starting a posgresql container (cit_postgres) then enabling it"
-        docker run --detach --env POSTGRES_PASSWORD=password --env POSTGRES_USER=tester --name cit_postgres --network ${CIT_NETWORK:-bridge} --rm  postgres:latest
+        docker run --detach --env POSTGRES_PASSWORD=password --env POSTGRES_USER=tester --name cit_postgres --network ${CIT_NETWORK:-citnet} --rm  postgres:latest
         sleep 3
         docker exec -i cit_postgres createdb -U tester testspace
     fi
 
     # run pytest
-    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" --network ${CIT_NETWORK:-bridge} -v $PWD:$PWD -u $UID -w $PWD niessner/cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
+    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" --network ${CIT_NETWORK:-citnet} -v $PWD:$PWD -u $UID -w $PWD niessner/cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
     [ 0 -lt `grep FAILED unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
     [ 0 -lt `grep "ERROR at" unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
 

--- a/.ci/check_03.sh
+++ b/.ci/check_03.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/check_03.sh
+++ b/.ci/check_03.sh
@@ -55,7 +55,7 @@ then
         units=Test
     fi
 
-    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" -v $PWD:$PWD -u $UID -w $PWD cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
+    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" --network ${CIT_NETWORK:-bridge} -v $PWD:$PWD -u $UID -w $PWD cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
     [ 0 -lt `grep FAILED unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
     [ 0 -lt `grep "ERROR at" unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
     state=`get_state`

--- a/.ci/check_03.sh
+++ b/.ci/check_03.sh
@@ -55,7 +55,7 @@ then
         units=Test
     fi
 
-    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" --network ${CIT_NETWORK:-bridge} -v $PWD:$PWD -u $UID -w $PWD cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
+    docker run --rm -e PYTHONPATH=${PWD}/Python -e USERNAME="$(whoami)" --network ${CIT_NETWORK:-bridge} -v $PWD:$PWD -u $UID -w $PWD niessner/cit:$(cit_version) python3 -m pytest --cov=dawgie --cov-branch --cov-report term-missing -v ${units} | tee unittest.rpt.txt
     [ 0 -lt `grep FAILED unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
     [ 0 -lt `grep "ERROR at" unittest.rpt.txt | wc -l` ]  && echo 'failure' > .ci/status.txt
     state=`get_state`

--- a/.ci/check_04.sh
+++ b/.ci/check_04.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/check_04.sh
+++ b/.ci/check_04.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/exercise_00.sh
+++ b/.ci/exercise_00.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/exercise_01.sh
+++ b/.ci/exercise_01.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/exercise_01.sh
+++ b/.ci/exercise_01.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/pypi.sh
+++ b/.ci/pypi.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/pypi.sh
+++ b/.ci/pypi.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/release_notes.sh
+++ b/.ci/release_notes.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/release_notes.sh
+++ b/.ci/release_notes.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/step_00.sh
+++ b/.ci/step_00.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/step_00.sh
+++ b/.ci/step_00.sh
@@ -64,19 +64,19 @@ then
        then
            echo "building CIT because $(docker images niessner/cit | grep ${citVersion})"
 
-           if [ -z "$(docker images | awk -e '{print $1":"$2}' | grep os:$osVersion)" ]
+           if [ -z "$(docker images | awk '{print $1":"$2}' | grep os:$osVersion)" ]
            then
                echo "   Building OS layer $osVersion"
                docker build --network=host -t os:${osVersion} - < .ci/Dockerfile.1
            fi
 
-           if [ -z "$(docker images | awk -e '{print $1":"$2}' | grep py:$pyVersion)" ]
+           if [ -z "$(docker images | awk '{print $1":"$2}' | grep py:$pyVersion)" ]
            then
                echo "   Building Python layer $pyVersion"
                docker build --network=host -t py:${pyVersion} - < .ci/Dockerfile.2
            fi
 
-           if [ -z "$(docker images | awk -e '{print $1":"$2}' | grep cit:$citVersion)" ]
+           if [ -z "$(docker images | awk '{print $1":"$2}' | grep cit:$citVersion)" ]
            then
                echo "   Building CI Tools layer $citVersion"
                docker build --network=host -t niessner/cit:${citVersion} - < .ci/Dockerfile.3

--- a/.ci/step_00.sh
+++ b/.ci/step_00.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/step_99.sh
+++ b/.ci/step_99.sh
@@ -2,7 +2,7 @@
 # need to signal the parent Jenkins script of failure if any step fails
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/step_99.sh
+++ b/.ci/step_99.sh
@@ -43,6 +43,6 @@ if current_state
 then
     echo ''
 else
-    echo 'exiting with code 1'
+    echo 'exiting with code 1: $(cat .ci/status.txt)'
     exit 1
 fi

--- a/.ci/step_99.sh
+++ b/.ci/step_99.sh
@@ -2,7 +2,7 @@
 # need to signal the parent Jenkins script of failure if any step fails
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/step_99.sh
+++ b/.ci/step_99.sh
@@ -43,6 +43,6 @@ if current_state
 then
     echo ''
 else
-    echo 'exiting with code 1: $(cat .ci/status.txt)'
+    echo "exiting with code 1: $(cat .ci/status.txt)"
     exit 1
 fi

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -130,7 +130,7 @@ post_state ()
          -H "Authorization: token ${GHE_TOKEN}" \
          ${GHE_API_URL}/repos/${REPO}/statuses/${CIRCLE_SHA1} \
          -d "{\"state\": \"${3}\", \"target_url\": \"${CIRCLE_BUILD_URL}\", \"description\": \"${2}\", \"context\": \"${1}\"}"  > /dev/null 2>&1
-    exit $(check_state)
+    exit $(current_state)
 }
 
 which_port ()

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -130,6 +130,7 @@ post_state ()
          -H "Authorization: token ${GHE_TOKEN}" \
          ${GHE_API_URL}/repos/${REPO}/statuses/${CIRCLE_SHA1} \
          -d "{\"state\": \"${3}\", \"target_url\": \"${CIRCLE_BUILD_URL}\", \"description\": \"${2}\", \"context\": \"${1}\"}"  > /dev/null 2>&1
+    exit $(check_state)
 }
 
 which_port ()

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -1,6 +1,6 @@
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -1,6 +1,6 @@
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -130,7 +130,6 @@ post_state ()
          -H "Authorization: token ${GHE_TOKEN}" \
          ${GHE_API_URL}/repos/${REPO}/statuses/${CIRCLE_SHA1} \
          -d "{\"state\": \"${3}\", \"target_url\": \"${CIRCLE_BUILD_URL}\", \"description\": \"${2}\", \"context\": \"${1}\"}"  > /dev/null 2>&1
-    exit $(current_state)
 }
 
 which_port ()

--- a/Bash/crew.sh
+++ b/Bash/crew.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Bash/crew.sh
+++ b/Bash/crew.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Bash/sdppiped.sh
+++ b/Bash/sdppiped.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Bash/sdppiped.sh
+++ b/Bash/sdppiped.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Bash/worker.sh
+++ b/Bash/worker.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Bash/worker.sh
+++ b/Bash/worker.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Python/Coda/aws_lambda.py
+++ b/Python/Coda/aws_lambda.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/Coda/aws_lambda.py
+++ b/Python/Coda/aws_lambda.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/Coda/build.sh
+++ b/Python/Coda/build.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Python/Coda/build.sh
+++ b/Python/Coda/build.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/Python/dawgie/__init__.py
+++ b/Python/dawgie/__init__.py
@@ -1,7 +1,7 @@
 '''
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/__init__.py
+++ b/Python/dawgie/__init__.py
@@ -1,7 +1,7 @@
 '''
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/context.py
+++ b/Python/dawgie/context.py
@@ -63,7 +63,7 @@ class PortOffset(enum.Enum):
 ae_base_path = os.environ.get ('AE_BASE_PATH', '/proj/src/ae')
 ae_base_package = os.environ.get ('AE_BASE_PACKAGE', 'ae')
 
-allow_promotion = bool(os.environ.get ('DAWGIE_PROMOTION', 'False'))
+allow_promotion = bool(os.environ.get ('DAWGIE_PROMOTION', ''))
 
 cloud_data = os.environ.get ('CLOUD_DATA','apikey@url@SQS_Name@AutoScalingGroupName@ClusterName@TaskDefinition')
 cloud_port = int(os.environ.get ('CLOUD_PORT', 8080 + PortOffset.cloud.value))

--- a/Python/dawgie/context.py
+++ b/Python/dawgie/context.py
@@ -1,7 +1,7 @@
 '''
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/context.py
+++ b/Python/dawgie/context.py
@@ -1,7 +1,7 @@
 '''
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/context.py
+++ b/Python/dawgie/context.py
@@ -63,6 +63,8 @@ class PortOffset(enum.Enum):
 ae_base_path = os.environ.get ('AE_BASE_PATH', '/proj/src/ae')
 ae_base_package = os.environ.get ('AE_BASE_PACKAGE', 'ae')
 
+allow_promotion = bool(os.environ.get ('DAWGIE_PROMOTION', 'False'))
+
 cloud_data = os.environ.get ('CLOUD_DATA','apikey@url@SQS_Name@AutoScalingGroupName@ClusterName@TaskDefinition')
 cloud_port = int(os.environ.get ('CLOUD_PORT', 8080 + PortOffset.cloud.value))
 cloud_provider = CloudProvider.none
@@ -122,6 +124,8 @@ def add_arguments (ap):
                      help='the complete path to the AE directory [%(default)s]')
     ap.add_argument ('--context-ae-pkg', default=ae_base_package,required=False,
                      help='the package prefix for the AE [%(default)s]')
+    ap.add_argument ('--context-allow-promotion', action='store_true',required=False,
+                     help='allow the dawgie to promote state vectors')
     ap.add_argument ('--context-cloud-data', default=cloud_data, required=False,
                      help='data used to communicate with the cloud provider')
     ap.add_argument ('--context-cloud-port', default=cloud_port, required=False, type=int,
@@ -242,6 +246,7 @@ def override (args):
 
     dawgie.context.ae_base_path = args.context_ae_dir
     dawgie.context.ae_base_package = args.context_ae_pkg
+    dawgie.context.allow_promotion = args.context_allow_promotion
     dawgie.context.cloud_data = args.context_cloud_data
     dawgie.context.cloud_port = args.context_cloud_port
     dawgie.context.cloud_provider = CloudProvider[args.context_cloud_provider]

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -87,7 +87,7 @@ def connect (alg, bot, tn):
     '''
     return _db_in_use().connect (alg, bot, tn)
 
-def consistent (inputs:[REF], output:REF, values:[CONSTRAINT])->():
+def consistent (inputs:[REF], outputs:[REF], values:[CONSTRAINT])->():
     '''Find self consistent inputs for the output returning base table entry
 
     REF - tid is Analysis/Regress/Task ID
@@ -95,9 +95,9 @@ def consistent (inputs:[REF], output:REF, values:[CONSTRAINT])->():
         - sid is StateVector ID
         - vid is Value ID
 
-    inputs - list of consistent inputs to find
-    output - for this output
-    values - constraints for the output whose ending values are already known
+    inputs  - list of consistent inputs to find
+    outputs - consistent for these outputs
+    values  - constraints for the output whose ending values are already known
 
     returns a tuple that can be used by dawgie.db.promote to create a new entry
             in the database that represents the same solution as if the AE

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -52,7 +52,7 @@ import dawgie.util
 import importlib
 import logging; log = logging.getLogger(__name__)
 
-ID = collections.namedtuple('ID', ['name', 'version'])
+ID = collections.namedtuple('ID', ['name', 'version'])  # version == dawgie.Version implementation
 REF = collections.namedtuple('REF', ['tid', 'aid', 'sid', 'vid'])
 
 METRIC_DATA = collections.namedtuple('METRIC_DATA', ['alg_name','alg_ver','sv',
@@ -89,10 +89,10 @@ def connect (alg, bot, tn):
 def consistent (inputs:[REF], outputs:[REF], target_name:str)->():
     '''Find self consistent inputs for the output returning base table entry
 
-    REF - tid is Analysis/Regress/Task ID
-        - aid is Algorithm/Analyzer/Regression ID
-        - sid is StateVector ID
-        - vid is Value ID
+    REF - tid is Analysis/Regress/Task dawgie.db.ID (use None for version)
+        - aid is Algorithm/Analyzer/Regression dawgie.db.ID
+        - sid is StateVector dawgie.db.ID
+        - vid is Value dawgie.db.ID
 
     inputs  - list of consistent inputs to find
     outputs - consistent for these outputs

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -8,7 +8,7 @@ The database interface has N goals:
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -52,7 +52,6 @@ import dawgie.util
 import importlib
 import logging; log = logging.getLogger(__name__)
 
-CONSTRAINT = collections.namedtuple('CONSTRAINT', ['runid', 'tgtn', 'ref'])
 ID = collections.namedtuple('ID', ['name', 'version'])
 REF = collections.namedtuple('REF', ['tid', 'aid', 'sid', 'vid'])
 
@@ -87,7 +86,7 @@ def connect (alg, bot, tn):
     '''
     return _db_in_use().connect (alg, bot, tn)
 
-def consistent (inputs:[REF], outputs:[REF], values:[CONSTRAINT])->():
+def consistent (inputs:[REF], outputs:[REF], target_name:str)->():
     '''Find self consistent inputs for the output returning base table entry
 
     REF - tid is Analysis/Regress/Task ID
@@ -97,14 +96,14 @@ def consistent (inputs:[REF], outputs:[REF], values:[CONSTRAINT])->():
 
     inputs  - list of consistent inputs to find
     outputs - consistent for these outputs
-    values  - constraints for the output whose ending values are already known
+    target_name - which target
 
     returns a tuple that can be used by dawgie.db.promote to create a new entry
             in the database that represents the same solution as if the AE
             were run given the inputs as it was already done. Returns an empty
             tuple or None if a consistent set of data could not be found.
     '''
-    return _db_in_use().consistent (inputs, output, values)
+    return _db_in_use().consistent (inputs, outputs, target_name)
 
 def copy (dst, method, gateway):
     '''Copy database to destination.'''

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -242,7 +242,7 @@ def view (visitor, runid, tn, tskn, algn, svn):
         visitor.add_declaration (msg)
         return
 
-    _db_in_use().reset (runid, tn, tskn, alg)
+    _db_in_use().reset (runid, tn, tskn, alg)  # set the alg version
     ds = connect (alg, bot, tn)
     ds.load()
 

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -137,7 +137,7 @@ def promote (juncture:(), runid:int):
     runid.target name.task name.alg name.state vector name.value name'''
     return _db_in_use().promote (juncture, runid)
 
-def remove(runid, tn, taskn, algn, svn, vn):
+def remove(runid:int, tn:str, taskn:str, algn:str, svn:str, vn:str):
     '''Remove the specified key from the primary table'''
     return _db_in_use().remove (runid, tn, taskn, algn, svn, vn)
 
@@ -163,7 +163,11 @@ def targets (fulllist:bool=False):
                                  (s.startswith ('__') and s.endswith ('__')),
                                  _db_in_use().targets())]
 
-def trace (task_alg_names):
+def trace (task_alg_names:[str])->{str:{str:int}}:
+    '''trace the task_alg_names to find the lastest runid for each target
+
+    returns {target_name:{task_alg_name:runid}}
+    '''
     return _db_in_use().trace (task_alg_names)
 
 def update (tsk, alg, sv, vn, v):

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -8,7 +8,7 @@ The database interface has N goals:
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -52,6 +52,10 @@ import dawgie.util
 import importlib
 import logging; log = logging.getLogger(__name__)
 
+CONSTRAINT = collections.namedtuple('CONSTRAINT', ['runid', 'tgtn', 'ref'])
+ID = collections.namedtuple('ID', ['name', 'version'])
+REF = collections.namedtuple('REF', ['tid', 'aid', 'sid', 'vid'])
+
 METRIC_DATA = collections.namedtuple('METRIC_DATA', ['alg_name','alg_ver','sv',
                                                      'run_id','target','task'])
 
@@ -83,6 +87,25 @@ def connect (alg, bot, tn):
     '''
     return _db_in_use().connect (alg, bot, tn)
 
+def consistent (inputs:[REF], output:REF, values:[CONSTRAINT])->():
+    '''Find self consistent inputs for the output returning base table entry
+
+    REF - tid is Analysis/Regress/Task ID
+        - aid is Algorithm/Analyzer/Regression ID
+        - sid is StateVector ID
+        - vid is Value ID
+
+    inputs - list of consistent inputs to find
+    output - for this output
+    values - constraints for the output whose ending values are already known
+
+    returns a tuple that can be used by dawgie.db.promote to create a new entry
+            in the database that represents the same solution as if the AE
+            were run given the inputs as it was already done. Returns an empty
+            tuple or None if a consistent set of data could not be found.
+    '''
+    return _db_in_use().consistent (inputs, output, values)
+
 def copy (dst, method, gateway):
     '''Copy database to destination.'''
     return _db_in_use().copy(dst, method, gateway)
@@ -105,6 +128,15 @@ def next():
 def open():
     '''Open the database'''
     return _db_in_use().open()
+
+def promote (junctures:[()], runid:int):
+    '''Promote the junctures to the given runid
+
+    juncture : a list of results from dawgie.db.consistent
+
+    retuns the full value names promoted as
+    runid.target name.task name.alg name.state vector name.value name'''
+    return _db_in_use().promote (junctures, runid)
 
 def remove(runid, tn, taskn, algn, svn, vn):
     '''Remove the specified key from the primary table'''

--- a/Python/dawgie/db/__init__.py
+++ b/Python/dawgie/db/__init__.py
@@ -128,14 +128,14 @@ def open():
     '''Open the database'''
     return _db_in_use().open()
 
-def promote (junctures:[()], runid:int):
+def promote (juncture:(), runid:int):
     '''Promote the junctures to the given runid
 
     juncture : a list of results from dawgie.db.consistent
 
     retuns the full value names promoted as
     runid.target name.task name.alg name.state vector name.value name'''
-    return _db_in_use().promote (junctures, runid)
+    return _db_in_use().promote (juncture, runid)
 
 def remove(runid, tn, taskn, algn, svn, vn):
     '''Remove the specified key from the primary table'''

--- a/Python/dawgie/db/lockview.py
+++ b/Python/dawgie/db/lockview.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/lockview.py
+++ b/Python/dawgie/db/lockview.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/post.py
+++ b/Python/dawgie/db/post.py
@@ -468,8 +468,8 @@ class Interface(dawgie.db.util.aspect.Container,dawgie.Dataset,dawgie.Timeline):
                                                     self._tn(),
                                                     self._task(),
                                                     self._alg().name(),
-                                                    sv.name(), vn])),
-                                        not exists)
+                                                    sv.name(), vn]),
+                                        not exists))
 
                 # Put result in primary. Make sure to get task_ID and other
                 # primary keys from their respective tables

--- a/Python/dawgie/db/post.py
+++ b/Python/dawgie/db/post.py
@@ -469,7 +469,7 @@ class Interface(dawgie.db.util.aspect.Container,dawgie.Dataset,dawgie.Timeline):
                                                     self._task(),
                                                     self._alg().name(),
                                                     sv.name(), vn]),
-                                        not exists))
+                                         not exists))
 
                 # Put result in primary. Make sure to get task_ID and other
                 # primary keys from their respective tables
@@ -1132,6 +1132,7 @@ def promote (juncture:(), runid:int):
     conn.close()
     return True
 
+# pylint: disable=too-many-arguments
 def remove (runid:int, tn:str, tskn:str, algn:str, svn:str, vn:str):
     if not dawgie.db.post._db: raise RuntimeError('called remove before open')
 

--- a/Python/dawgie/db/post.py
+++ b/Python/dawgie/db/post.py
@@ -794,30 +794,30 @@ def consistent (inputs:[REF], outputs:[REF], target_name:str)->():
         cur.execute('SELECT pk FROM Algorithm WHERE name = %s AND ' +
                     'task_ID = %s AND design = %s AND implementation = %s ' +
                     'bugfix = %s;',
-                    (output.aid.name, task_ID, output.aid.verion.design(),
-                     output.aid.verion.implementation(),
-                     output.aid.verion.bugfix()))
+                    (output.aid.name, task_ID, output.aid.version.design(),
+                     output.aid.version.implementation(),
+                     output.aid.version.bugfix()))
         alg_ID = _fetchone (cur,
                             ('consistent(): Algorithm "%s %s" is not singular' %
-                             (output.aid.name, output.aid.verion.asstring())))
+                             (output.aid.name, output.aid.version.asstring())))
         cur.execute('SELECT pk FROM StateVector WHERE name = %s AND ' +
                     'alg_ID = %s AND design = %s AND implementation = %s ' +
                     'bugfix = %s;',
-                    (output.sid.name, alg_ID, output.sid.verion.design(),
-                     output.sid.verion.implementation(),
-                     output.sid.verion.bugfix()))
+                    (output.sid.name, alg_ID, output.sid.version.design(),
+                     output.sid.version.implementation(),
+                     output.sid.version.bugfix()))
         sv_ID = _fetchone (cur,
                            ('consistent(): SV "%s %s" is not singular' %
-                            (output.sid.name, output.sid.verion.asstring())))
+                            (output.sid.name, output.sid.version.asstring())))
         cur.execute('SELECT pk FROM Value WHERE name = %s AND ' +
                     'sv_ID = %s AND design = %s AND implementation = %s ' +
                     'bugfix = %s;',
-                    (output.vid.name, sv_ID, output.vid.verion.design(),
-                     output.vid.verion.implementation(),
-                     output.vid.verion.bugfix()))
+                    (output.vid.name, sv_ID, output.vid.version.design(),
+                     output.vid.version.implementation(),
+                     output.vid.version.bugfix()))
         v_ID = _fetchone (cur,
                           ('consistent(): Value "%s %s" is not singular' %
-                           (output.vid.name, output.vid.verion.asstring())))
+                           (output.vid.name, output.vid.version.asstring())))
         cur.execute('SELECT runid FROM Prime WHERE tn_ID = %s AND ' +
                     'task_ID = %s AND alg_ID = %s AND sv_ID = %s AND ' +
                     'val_ID = %s;',
@@ -916,30 +916,30 @@ def consistent (inputs:[REF], outputs:[REF], target_name:str)->():
         cur.execute('SELECT pk FROM Algorithm WHERE name = %s AND ' +
                     'task_ID = %s AND design = %s AND implementation = %s ' +
                     'bugfix = %s;',
-                    (output.aid.name, task_ID, output.aid.verion.design(),
-                     output.aid.verion.implementation(),
-                     output.aid.verion.bugfix()))
+                    (output.aid.name, task_ID, output.aid.version.design(),
+                     output.aid.version.implementation(),
+                     output.aid.version.bugfix()))
         alg_ID = _fetchone (cur,
                             ('consistent(): Algorithm "%s %s" is not singular' %
-                             (output.aid.name, output.aid.verion.asstring())))
+                             (output.aid.name, output.aid.version.asstring())))
         cur.execute('SELECT pk FROM StateVector WHERE name = %s AND ' +
                     'alg_ID = %s AND design = %s AND implementation = %s ' +
                     'bugfix = %s;',
-                    (output.sid.name, alg_ID, output.sid.verion.design(),
-                     output.sid.verion.implementation(),
-                     output.sid.verion.bugfix()))
+                    (output.sid.name, alg_ID, output.sid.version.design(),
+                     output.sid.version.implementation(),
+                     output.sid.version.bugfix()))
         sv_ID = _fetchone (cur,
                            ('consistent(): SV "%s %s" is not singular' %
-                            (output.sid.name, output.sid.verion.asstring())))
+                            (output.sid.name, output.sid.version.asstring())))
         cur.execute('SELECT pk FROM Value WHERE name = %s AND ' +
                     'sv_ID = %s AND design = %s AND implementation = %s ' +
                     'bugfix = %s;',
-                    (output.vid.name, sv_ID, output.vid.verion.design(),
-                     output.vid.verion.implementation(),
-                     output.vid.verion.bugfix()))
+                    (output.vid.name, sv_ID, output.vid.version.design(),
+                     output.vid.version.implementation(),
+                     output.vid.version.bugfix()))
         v_ID = _fetchone (cur,
                           ('consistent(): Value "%s %s" is not singular' %
-                           (output.vid.name, output.vid.verion.asstring())))
+                           (output.vid.name, output.vid.version.asstring())))
         cur.execute('SELECT blob_name FROM Prime WHERE runid = %s AND ' +
                     'tn_ID = %s AND task_ID = %s AND alg_ID = %s AND ' +
                     'sv_ID = %s AND val_ID = %s;',

--- a/Python/dawgie/db/post.py
+++ b/Python/dawgie/db/post.py
@@ -2,7 +2,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/post.py
+++ b/Python/dawgie/db/post.py
@@ -2,7 +2,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/shelf.py
+++ b/Python/dawgie/db/shelf.py
@@ -49,7 +49,6 @@ import datetime
 import enum
 import dawgie
 import dawgie.context
-from dawgie.db import CONSTRAINT
 from dawgie.db import REF
 import dawgie.db.lockview
 import dawgie.db.shelf
@@ -772,7 +771,7 @@ def connect (alg, bot, tn):
         raise RuntimeError('called connect before open')
     return Interface(alg, bot, tn)
 
-def consistent (_inputs:[REF], _outputs:[REF], _values:[CONSTRAINT])->():
+def consistent (_inputs:[REF], _outputs:[REF], _target_name:str)->():
     raise NotImplementedError('Not ready for shelf')
 
 def copy(dst, method=Method.connector, gateway=dawgie.context.db_host):

--- a/Python/dawgie/db/shelf.py
+++ b/Python/dawgie/db/shelf.py
@@ -49,6 +49,8 @@ import datetime
 import enum
 import dawgie
 import dawgie.context
+from dawgie.db import CONSTRAINT
+from dawgie.db import REF
 import dawgie.db.lockview
 import dawgie.db.shelf
 import dawgie.db.util
@@ -65,7 +67,6 @@ import twisted.internet.protocol
 import twisted.internet.reactor
 import twisted.internet.task
 import twisted.internet.threads
-
 
 COMMAND = collections.namedtuple('COMMAND', ['func', 'key', 'table', 'value'])
 TABLES = collections.namedtuple('TABLES', ['alg', 'primary',
@@ -771,6 +772,9 @@ def connect (alg, bot, tn):
         raise RuntimeError('called connect before open')
     return Interface(alg, bot, tn)
 
+def consistent (_inputs:[REF], _outputs:[REF], _values:[CONSTRAINT])->():
+    raise NotImplementedError('Not ready for shelf')
+
 def copy(dst, method=Method.connector, gateway=dawgie.context.db_host):
     if dawgie.db.shelf._db is None:
         raise RuntimeError('called copy before open')
@@ -898,6 +902,9 @@ def open_shelve(path):
                   target=shelve.open (path + '.target'),
                   task=shelve.open (path + '.task'),
                   value=shelve.open (path + '.value'))
+
+def promote (_junctures:[()], _runid:int):
+    raise NotImplementedError('Not ready for shelf')
 
 # pylint: disable=too-many-arguments
 def remove (runid, tn, taskn, algn, svn, vn):

--- a/Python/dawgie/db/shelf.py
+++ b/Python/dawgie/db/shelf.py
@@ -946,7 +946,7 @@ def rotated_files(index=None):
 def retreat (reg, ret):
     if dawgie.db.shelf._db is None:
         raise RuntimeError('called connect before open')
-    return Interface(reg, ret, ret._target)
+    return Interface(reg, ret, ret._target())
 
 def targets():
     if isinstance (dawgie.db.shelf._db, bool): result = Connector()._keys (Table.target)

--- a/Python/dawgie/db/shelf.py
+++ b/Python/dawgie/db/shelf.py
@@ -6,7 +6,7 @@ It does not support wildcarding.
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/shelf.py
+++ b/Python/dawgie/db/shelf.py
@@ -6,7 +6,7 @@ It does not support wildcarding.
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/shelf.py
+++ b/Python/dawgie/db/shelf.py
@@ -902,7 +902,7 @@ def open_shelve(path):
                   task=shelve.open (path + '.task'),
                   value=shelve.open (path + '.value'))
 
-def promote (_junctures:[()], _runid:int):
+def promote (_junctures:(), _runid:int):
     raise NotImplementedError('Not ready for shelf')
 
 # pylint: disable=too-many-arguments

--- a/Python/dawgie/db/test.py
+++ b/Python/dawgie/db/test.py
@@ -1,7 +1,7 @@
 ''' unit testing implementation of dawgie.db
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/test.py
+++ b/Python/dawgie/db/test.py
@@ -1,7 +1,7 @@
 ''' unit testing implementation of dawgie.db
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/test.py
+++ b/Python/dawgie/db/test.py
@@ -39,11 +39,15 @@ NTR: 49811
 
 # pylint: disable=redefined-builtin,too-many-arguments,unused-argument
 
+from dawgie.db import REF
+
 def archive (done): raise NotImplementedError()
 
 def close(): return
 
 def connect (alg, bot, tn): raise NotImplementedError()
+
+def consistent (inputs:[REF], outputs:[REF], target_name:str)->(): raise NotImplementedError()
 
 def copy (dst, method, gateway): raise NotImplementedError()
 
@@ -54,6 +58,8 @@ def metrics()->'[dawgie.db.METRIC_DATA]': raise NotImplementedError()
 def next(): raise NotImplementedError()
 
 def open(): raise NotImplementedError()
+
+def promote (juncture:(), runid:int): raise NotImplementedError()
 
 def remove(runid, tn, taskn, algn, svn, vn): raise NotImplementedError()
 

--- a/Python/dawgie/db/testdata.py
+++ b/Python/dawgie/db/testdata.py
@@ -46,6 +46,12 @@ RUNID = 17
 TARGET = 'test'
 TIMELINES = []
 
+ALG_CNT = 11
+SVN_CNT = 7
+TSK_CNT = 13
+VAL_CNT = 5
+VER_CNT = 3
+
 class Fake(dawgie.Algorithm,dawgie.Analyzer,dawgie.Regression):
     def __init__(self, name, bug):
         self._version_ = dawgie.VERSION(1,1,bug)
@@ -96,16 +102,16 @@ class Task(dawgie.Task):
     pass
 
 class Value(dawgie.Value):
-    def __init__(self, val):
+    def __init__(self, val=None):
         self._version_ = dawgie.VERSION(5,6,7)
-        self.val = val
+        if not val: self.val = val
         return
     def features(self): return []
     def get(self): return self.val
     def set(self, val): self.val = val
     pass
 
-for tsk_idx in range(13):
+for tsk_idx in range(TSK_CNT):
     rem = tsk_idx % 3
     tidx = tsk_idx // 3
 
@@ -113,19 +119,22 @@ for tsk_idx in range(13):
     if rem == 1: tsk = Regress('Regress_{:02d}'.format (tidx), 0, TARGET)
     if rem == 2: tsk = Task('Task_{:02d}'.format (tidx), 0, RUNID, TARGET)
 
-    for ver_idx in range(3):
-        for alg_idx in range(11):
+    for ver_idx in range(VER_CNT):
+        for alg_idx in range(ALG_CNT):
             if rem == 0: base = 'Analyzer'
             if rem == 1: base = 'Regression'
-            if rem == 2: base = 'Task'
+            if rem == 2: base = 'Algorithm'
 
             base += '_{:02d}'
             alg = Fake(base.format (alg_idx), ver_idx)
             tsk.mylist.append (alg)
-            for svn_idx in range(7):
-                sv = StateVector('StateVector_{:02d}'.format(svn_idx))
+            for svn_idx in range(SVN_CNT):
+                if svn_idx < SVN_CNT-1:
+                    sv = StateVector('StateVector_{:02d}'.format(svn_idx))
+                else: sv = StateVector('__metric__')
+
                 alg.sv.append (sv)
-                for val_idx in range(5):
+                for val_idx in range(VAL_CNT):
                     vn = 'Value_{:02d}'.format (val_idx)
                     sv[vn] = Value(-(len(KNOWNS)+1))
                     KNOWNS.append ((tsk, alg, sv, vn, sv[vn]))

--- a/Python/dawgie/db/testdata.py
+++ b/Python/dawgie/db/testdata.py
@@ -1,0 +1,141 @@
+'''test data set for test13 and potenitally other uses
+
+COPYRIGHT:
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+U.S. Government sponsorship acknowledged.
+
+All rights reserved.
+
+LICENSE:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of Caltech nor its operating division, the Jet
+Propulsion Laboratory, nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+NTR:
+'''
+
+import dawgie
+
+ASPECTS = []
+DATASETS = []
+JUNCTURES = []
+KNOWNS = []
+RUNID = 17
+TARGET = 'test'
+TIMELINES = []
+
+class Fake(dawgie.Algorithm,dawgie.Analyzer,dawgie.Regression):
+    def __init__(self, name, bug):
+        self._version_ = dawgie.VERSION(1,1,bug)
+        self.myname = name
+        self.sv = []
+        pass
+    def name(self): return self.myname
+    def previous(self): return []
+    # pylint: disable=arguments-differ,unused-argument
+    def run(self, *args, **kwds): return
+    # pylint: enable=arguments-differ,unused-argument
+    def state_vectors(self): return self.sv
+    def traits(self): return []
+    def variables(self): return []
+    pass
+
+class Analysis(dawgie.Analysis):
+    def __init__(self, name, ps_hint, runid):
+        dawgie.Analysis.__init__(self, name, ps_hint, runid)
+        self.mylist = []
+        return
+    def list(self): return self.mylist
+    pass
+
+class Regress(dawgie.Regress):
+    def __init__(self, name, ps_hint, target):
+        dawgie.Regress.__init__ (self, name, ps_hint, target)
+        self.mylist = []
+        return
+    def list(self): return self.mylist
+    pass
+
+class StateVector(dawgie.StateVector):
+    def __init__(self, name):
+        self.myname = name
+        self._version_ = dawgie.VERSION(1,2,3)
+        return
+    def name(self): return self.myname
+    def view(self, visitor): return
+    pass
+
+class Task(dawgie.Task):
+    def __init__(self, name, ps_hint, runid, target='__all__'):
+        dawgie.Task.__init__(self, name, ps_hint, runid, target)
+        self.mylist = []
+        return
+    def list(self): return self.mylist
+    pass
+
+class Value(dawgie.Value):
+    def __init__(self, val):
+        self._version_ = dawgie.VERSION(5,6,7)
+        self.val = val
+        return
+    def features(self): return []
+    def get(self): return self.val
+    def set(self, val): self.val = val
+    pass
+
+for tsk_idx in range(13):
+    rem = tsk_idx % 3
+    tidx = tsk_idx // 3
+
+    if rem == 0: tsk = Analysis('Analysis_{:02d}'.format (tidx), 0, RUNID)
+    if rem == 1: tsk = Regress('Regress_{:02d}'.format (tidx), 0, TARGET)
+    if rem == 2: tsk = Task('Task_{:02d}'.format (tidx), 0, RUNID, TARGET)
+
+    for ver_idx in range(3):
+        for alg_idx in range(11):
+            if rem == 0: base = 'Analyzer'
+            if rem == 1: base = 'Regression'
+            if rem == 2: base = 'Task'
+
+            base += '_{:02d}'
+            alg = Fake(base.format (alg_idx), ver_idx)
+            tsk.mylist.append (alg)
+            for svn_idx in range(7):
+                sv = StateVector('StateVector_{:02d}'.format(svn_idx))
+                alg.sv.append (sv)
+                for val_idx in range(5):
+                    vn = 'Value_{:02d}'.format (val_idx)
+                    sv[vn] = Value(-(len(KNOWNS)+1))
+                    KNOWNS.append ((tsk, alg, sv, vn, sv[vn]))
+                    pass
+                pass
+            pass
+        pass
+
+    if rem == 0: ASPECTS.append ((tsk, alg))
+    if rem == 1: TIMELINES.append ((tsk, alg))
+    if rem == 2: DATASETS.append ((TARGET, tsk, alg))
+    pass

--- a/Python/dawgie/db/testdata.py
+++ b/Python/dawgie/db/testdata.py
@@ -1,7 +1,7 @@
 '''test data set for test13 and potenitally other uses
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/testdata.py
+++ b/Python/dawgie/db/testdata.py
@@ -41,7 +41,6 @@ import dawgie
 
 ASPECTS = []
 DATASETS = []
-JUNCTURES = []
 KNOWNS = []
 RUNID = 17
 TARGET = 'test'

--- a/Python/dawgie/db/testdata.py
+++ b/Python/dawgie/db/testdata.py
@@ -48,7 +48,7 @@ TIMELINES = []
 
 ALG_CNT = 11
 SVN_CNT = 7
-TSK_CNT = 13
+TSK_CNT = 19
 VAL_CNT = 5
 VER_CNT = 3
 
@@ -56,10 +56,11 @@ class Fake(dawgie.Algorithm,dawgie.Analyzer,dawgie.Regression):
     def __init__(self, name, bug):
         self._version_ = dawgie.VERSION(1,1,bug)
         self.myname = name
+        self.prev = []
         self.sv = []
         pass
     def name(self): return self.myname
-    def previous(self): return []
+    def previous(self): return self.prev
     # pylint: disable=arguments-differ,unused-argument
     def run(self, *args, **kwds): return
     # pylint: enable=arguments-differ,unused-argument
@@ -147,3 +148,22 @@ for tsk_idx in range(TSK_CNT):
     if rem == 1: TIMELINES.append ((tsk, alg))
     if rem == 2: DATASETS.append ((TARGET, tsk, alg))
     pass
+
+# If these change, then will need to update
+# test_13.{test_consistent,test_promote}
+for a,r,t in zip(ASPECTS,TIMELINES,DATASETS):
+    a[1].prev = [dawgie.SV_REF(None, r[1], sv) for sv in r[1].sv]
+    r[1].prev = [dawgie.SV_REF(None, t[2], sv) for sv in t[2].sv]
+    pass
+DATASETS[1][2].prev = [dawgie.SV_REF(None, DATASETS[0][2], sv)
+                       for sv in DATASETS[0][2].sv]
+DATASETS[2][2].prev = ([dawgie.SV_REF(None, DATASETS[0][2], sv)
+                        for sv in DATASETS[0][2].sv] +
+                       [dawgie.SV_REF(None, DATASETS[1][2], sv)
+                        for sv in DATASETS[1][2].sv])
+DATASETS[3][2].prev = [dawgie.SV_REF(None, DATASETS[0][2], sv)
+                       for sv in DATASETS[0][2].sv]
+DATASETS[4][2].prev = [dawgie.SV_REF(None, DATASETS[2][2], sv)
+                       for sv in DATASETS[2][2].sv]
+DATASETS[5][2].prev = [dawgie.SV_REF(None, DATASETS[1][2], sv)
+                       for sv in DATASETS[1][2].sv]

--- a/Python/dawgie/db/tools/__init__.py
+++ b/Python/dawgie/db/tools/__init__.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/__init__.py
+++ b/Python/dawgie/db/tools/__init__.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/dbsinfo.py
+++ b/Python/dawgie/db/tools/dbsinfo.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/dbsinfo.py
+++ b/Python/dawgie/db/tools/dbsinfo.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/extract.py
+++ b/Python/dawgie/db/tools/extract.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/extract.py
+++ b/Python/dawgie/db/tools/extract.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/inter.py
+++ b/Python/dawgie/db/tools/inter.py
@@ -2,7 +2,7 @@
 '''tool to inter data for a mausoleum
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/list.py
+++ b/Python/dawgie/db/tools/list.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/list.py
+++ b/Python/dawgie/db/tools/list.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/post2shelve.py
+++ b/Python/dawgie/db/tools/post2shelve.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/post2shelve.py
+++ b/Python/dawgie/db/tools/post2shelve.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/purge.py
+++ b/Python/dawgie/db/tools/purge.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/purge.py
+++ b/Python/dawgie/db/tools/purge.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/sandbox.py
+++ b/Python/dawgie/db/tools/sandbox.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/sandbox.py
+++ b/Python/dawgie/db/tools/sandbox.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/util.py
+++ b/Python/dawgie/db/tools/util.py
@@ -1,7 +1,7 @@
 '''General utility functions for all of the DB tools
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/util.py
+++ b/Python/dawgie/db/tools/util.py
@@ -1,7 +1,7 @@
 '''General utility functions for all of the DB tools
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/worm.py
+++ b/Python/dawgie/db/tools/worm.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/worm.py
+++ b/Python/dawgie/db/tools/worm.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/tools/worm.py
+++ b/Python/dawgie/db/tools/worm.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     import dawgie.util
 
     unique_fn = '.'.join (['worm', getpass.getuser(), 'log'])
-    ap = argparse.ArgumentParser(description='Crawls throught the database and removes all the matching keys from the primary table. It does not remove the referenced data in the store. There is no undo of this operation and it must be done to a database that is not active (the pipeline is not running.')
+    ap = argparse.ArgumentParser(description='Crawls through the database and removes all the matching keys from the primary table. It does not remove the referenced data in the store. There is no undo of this operation and it must be done to a database that is not active (the pipeline is not running.')
     ap.add_argument ('-l', '--log-file', default=unique_fn, required=False,
                      help='a filename to put all of the log messages into [%(default)s]')
     ap.add_argument ('-L', '--log-level', default=logging.INFO, required=False,

--- a/Python/dawgie/db/util/__init__.py
+++ b/Python/dawgie/db/util/__init__.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/util/__init__.py
+++ b/Python/dawgie/db/util/__init__.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/util/aspect.py
+++ b/Python/dawgie/db/util/aspect.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/db/util/aspect.py
+++ b/Python/dawgie/db/util/aspect.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/de/__init__.py
+++ b/Python/dawgie/de/__init__.py
@@ -1,7 +1,7 @@
 '''The display engines.
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/de/__init__.py
+++ b/Python/dawgie/de/__init__.py
@@ -1,7 +1,7 @@
 '''The display engines.
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/de/html.py
+++ b/Python/dawgie/de/html.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/de/html.py
+++ b/Python/dawgie/de/html.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/__init__.py
+++ b/Python/dawgie/fe/__init__.py
@@ -127,11 +127,13 @@ class RoutePoint(twisted.web.resource.Resource):
 
     def getChild (self, path, request):
         msg = request.uri.decode() if os.environ.get('DAWGIE_FE_DEBUG','') else 'DAWGIE_FE_DEBUG'
+        try: dpath = path.decode()
+        except UnicodeDecodeError: dpath = 'cannot decode "path"'
         return twisted.web.resource.ErrorPage(404,
                                               'Could not locate requested URI',
                                               '<p>%(my_name)s.getChild().name:         %(name)s<br>%(my_name)s.getChild().request.uri:  %(uri)s</p>' %
                                               {'my_name':self.__name,
-                                               'name': path.decode(),
+                                               'name': dpath,
                                                'uri':msg})
     pass
 

--- a/Python/dawgie/fe/__init__.py
+++ b/Python/dawgie/fe/__init__.py
@@ -1,7 +1,7 @@
 '''Built-in Front-End for DAWGIE
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/__init__.py
+++ b/Python/dawgie/fe/__init__.py
@@ -1,7 +1,7 @@
 '''Built-in Front-End for DAWGIE
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/__main__.py
+++ b/Python/dawgie/fe/__main__.py
@@ -1,7 +1,7 @@
 '''Built-in Front-End for DAWGIE
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/__main__.py
+++ b/Python/dawgie/fe/__main__.py
@@ -1,7 +1,7 @@
 '''Built-in Front-End for DAWGIE
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/app.py
+++ b/Python/dawgie/fe/app.py
@@ -1,7 +1,7 @@
 '''Define the bits of the front end that require some help from the server
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/app.py
+++ b/Python/dawgie/fe/app.py
@@ -1,7 +1,7 @@
 '''Define the bits of the front end that require some help from the server
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/about/index.html
+++ b/Python/dawgie/fe/pages/about/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/about/index.html
+++ b/Python/dawgie/fe/pages/about/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/algorithms/index.html
+++ b/Python/dawgie/fe/pages/algorithms/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/algorithms/index.html
+++ b/Python/dawgie/fe/pages/algorithms/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/command/index.html
+++ b/Python/dawgie/fe/pages/command/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/command/index.html
+++ b/Python/dawgie/fe/pages/command/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/index.html
+++ b/Python/dawgie/fe/pages/database/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/index.html
+++ b/Python/dawgie/fe/pages/database/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/primary_table/index.html
+++ b/Python/dawgie/fe/pages/database/primary_table/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/primary_table/index.html
+++ b/Python/dawgie/fe/pages/database/primary_table/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/targets/index.html
+++ b/Python/dawgie/fe/pages/database/targets/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/targets/index.html
+++ b/Python/dawgie/fe/pages/database/targets/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/tasks/index.html
+++ b/Python/dawgie/fe/pages/database/tasks/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/tasks/index.html
+++ b/Python/dawgie/fe/pages/database/tasks/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/versions/index.html
+++ b/Python/dawgie/fe/pages/database/versions/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/database/versions/index.html
+++ b/Python/dawgie/fe/pages/database/versions/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/exoplanet_systems/index.html
+++ b/Python/dawgie/fe/pages/exoplanet_systems/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/exoplanet_systems/index.html
+++ b/Python/dawgie/fe/pages/exoplanet_systems/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/index.html
+++ b/Python/dawgie/fe/pages/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/index.html
+++ b/Python/dawgie/fe/pages/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/logs/index.html
+++ b/Python/dawgie/fe/pages/logs/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/logs/index.html
+++ b/Python/dawgie/fe/pages/logs/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/pipelines/index.html
+++ b/Python/dawgie/fe/pages/pipelines/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/pipelines/index.html
+++ b/Python/dawgie/fe/pages/pipelines/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/schedule/index.html
+++ b/Python/dawgie/fe/pages/schedule/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/schedule/index.html
+++ b/Python/dawgie/fe/pages/schedule/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/search/index.html
+++ b/Python/dawgie/fe/pages/search/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/search/index.html
+++ b/Python/dawgie/fe/pages/search/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/tasks/index.html
+++ b/Python/dawgie/fe/pages/tasks/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/pages/tasks/index.html
+++ b/Python/dawgie/fe/pages/tasks/index.html
@@ -3,7 +3,7 @@
   <head>
     <!--
       COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/submit.py
+++ b/Python/dawgie/fe/submit.py
@@ -1,7 +1,7 @@
 '''Define a deferred rendering of a state vector
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/submit.py
+++ b/Python/dawgie/fe/submit.py
@@ -1,7 +1,7 @@
 '''Define a deferred rendering of a state vector
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/svrender.py
+++ b/Python/dawgie/fe/svrender.py
@@ -1,7 +1,7 @@
 '''Define a deferred rendering of a state vector
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/fe/svrender.py
+++ b/Python/dawgie/fe/svrender.py
@@ -1,7 +1,7 @@
 '''Define a deferred rendering of a state vector
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/__init__.py
+++ b/Python/dawgie/pl/__init__.py
@@ -8,7 +8,7 @@ The pipeline system has N goals:
   4. Distribute work across cores and nodes.
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/__init__.py
+++ b/Python/dawgie/pl/__init__.py
@@ -8,7 +8,7 @@ The pipeline system has N goals:
   4. Distribute work across cores and nodes.
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/__main__.py
+++ b/Python/dawgie/pl/__main__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/__main__.py
+++ b/Python/dawgie/pl/__main__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/dag.py
+++ b/Python/dawgie/pl/dag.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/dag.py
+++ b/Python/dawgie/pl/dag.py
@@ -49,6 +49,18 @@ import xml.etree.ElementTree
 
 class Construct(object):
     # pylint: disable=too-many-instance-attributes
+    def __getitem__(self, key):
+        result = []
+
+        if key.count ('.') == 3: result.append (self._flat[key])
+        else:
+            key = key + '.'
+            for k in self._flat:
+                if k.startswith (key): result.append (self._flat[k])
+                pass
+            pass
+        return result
+
     def __init__(self, factories):
         self._flat = {}
         self._roots = set()

--- a/Python/dawgie/pl/dag.py
+++ b/Python/dawgie/pl/dag.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/farm.py
+++ b/Python/dawgie/pl/farm.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/farm.py
+++ b/Python/dawgie/pl/farm.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/jobinfo.py
+++ b/Python/dawgie/pl/jobinfo.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/jobinfo.py
+++ b/Python/dawgie/pl/jobinfo.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/logger/__init__.py
+++ b/Python/dawgie/pl/logger/__init__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/logger/__init__.py
+++ b/Python/dawgie/pl/logger/__init__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/logger/fe.py
+++ b/Python/dawgie/pl/logger/fe.py
@@ -1,7 +1,7 @@
 '''
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/logger/fe.py
+++ b/Python/dawgie/pl/logger/fe.py
@@ -1,7 +1,7 @@
 '''
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/message.py
+++ b/Python/dawgie/pl/message.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/message.py
+++ b/Python/dawgie/pl/message.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -1,0 +1,76 @@
+'''
+COPYRIGHT:
+Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+U.S. Government sponsorship acknowledged.
+
+All rights reserved.
+
+LICENSE:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of Caltech nor its operating division, the Jet
+Propulsion Laboratory, nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+NTR:
+'''
+
+import dawgie.pl.dag
+import logging; log = logging.getLogger(__name__)
+
+class Engine:
+    def __call__ (self,
+                  values:[(str,bool)]=None,
+                  original:dawgie.pl.dag.Node=None,
+                  rid:int=None):
+        arg_state = (values is not None, original is not None, rid is not None)
+
+        if all (arg_state):  # new item to promote
+            self.todo (original, rid, values)
+        elif any (arg_state):  # error because its all or nothing
+            log.error ('Inconsistent arguments. Ignoring request.')
+        else: self.do()
+
+        return self.more()
+
+    def __init__ (self):
+        self._todo = []
+        return
+
+    def clear(self): self._todo.clear()
+
+    def do (self):
+        if self.more(): self.clear()
+        return
+
+    def more (self)->bool: return 0 < len (self._todo)
+
+    def todo (self,
+              original:dawgie.pl.dag.Node=None,
+              rid:int=None,
+              values:[(str,bool)]=None):
+        if not all ([v[1] for v in values]):\
+           self._todo.append ((original, rid, values))
+        return
+    pass

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -64,7 +64,7 @@ class Engine:
     def do (self):
         if self.more() and dawgie.context.allow_promotion:
             orig,rid,vals = self._todo.pop(0)
-            # 1: pop(0) value
+
             # 2: does decendent require subset of values
             #    if no, then break
             # 3: is the dependent schduled to run already or are running

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -120,7 +120,11 @@ class Engine:
                     continue
 
                 # 5: promote decendent state vectors
-                outputs = dawgie.db.promote (juncture, runid)
+                if not dawgie.db.promote (juncture, runid):
+                    self._organize ([child.tag], runid, targets,
+                                    'promition failed to insert')
+                    continue
+
                 # 6: add decendent to todo list
                 self._todo.append (child, runid, outputs)
                 pass

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -56,13 +56,22 @@ class Engine:
         return self.more()
 
     def __init__ (self):
+        self._ae = None
         self._todo = []
         return
+
+    @property
+    def ae(self)->dawgie.pl.dag.Construct: return self._ae
+
+    @ae.setter
+    def ae(self, ae:dawgie.pl.dag.Construct): self._ae = ae
 
     def clear(self): self._todo.clear()
 
     def do (self):
-        if self.more() and dawgie.context.allow_promotion:
+        if dawgie.context.allow_promotion and self.ae is None:
+            raise ValueError('AE is not set prior to data flow')
+        if dawgie.context.allow_promotion and self.more():
             orig,rid,vals = self._todo.pop(0)
 
             # 2: does decendent require subset of values

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -36,8 +36,10 @@ POSSIBILITY OF SUCH DAMAGE.
 NTR:
 '''
 
+import dawgie.db
 import dawgie.context
 import dawgie.pl.dag
+import dawgie.util
 import logging; log = logging.getLogger(__name__)
 
 class Engine:
@@ -57,8 +59,20 @@ class Engine:
 
     def __init__ (self):
         self._ae = None
+        self._organize = None
         self._todo = []
         return
+
+    def _as_constraints (self, values:[str])->[dawgie.db.CONSTRAINT]:
+        result = []
+        for v in values:
+            runid,target,tn,an,sn,vn = v.split ('.')
+            name = '.'.join ([tn,an,sn,vn])
+            result.append(dawgie.db.CONSTRAINT(runid=runid,
+                                               tgtn=target,
+                                               ref=_translate([self.ae[name]])))
+            pass
+        return result
 
     @property
     def ae(self)->dawgie.pl.dag.Construct: return self._ae
@@ -71,21 +85,60 @@ class Engine:
     def do (self):
         if dawgie.context.allow_promotion and self.ae is None:
             raise ValueError('AE is not set prior to data flow')
+        if dawgie.context.allow_promotion and self.organize is None:
+            raise ValueError('Organizer is not set prior to data flow')
         if dawgie.context.allow_promotion and self.more():
-            orig,rid,vals = self._todo.pop(0)
+            algnode,runid,values = self._todo.pop(0)
+            constraints = self._as_constraints (values)
+            name = algnode.tag + '.'
+            targets = set([v.split ('.')[1] for v in values])
+            vals = set(['.'.join (v.split ('.')[2:]) for v in values])
+            for child in algnode:
+                # 1: does decendent require subset of values
+                #  if no, then break
+                inputs = set()
+                outputs = self._ae[child.tag]
+                for o in outputs: inputs.update (o.get('parents'))
+                dependents = [d for d in
+                              filter (lambda i,n=name:i.tag.startswith(n),
+                                      inputs)]
 
-            # 2: does decendent require subset of values
-            #    if no, then break
-            # 3: is the dependent schduled to run already or are running
-            #    if yes, then break
-            # 4: are any of the dependent's other ancestors are scheduled or running
-            #    if yes, then break
-            # 5: promote decendent state vectors
-            # 6: add decendent to todo list
+                if not set(dependents).issubset (vals): continue
+
+                # 2: is the dependent or ancestors are schduled to run already
+                #    or are running
+                #  if yes, then break
+                if _is_scheduled (algnode, child, targets): continue
+
+                # 3: find the consistent set of previous inputs for each output
+                #    in this child
+                juncture = [dawgie.db.consistent (_translate (o.get('parents')),
+                                                  _translate ([o])[0],
+                                                  constraints)
+                            for o in outputs]
+
+                # 4: are all of the inputs to dependent the same
+                #    if no, schedule dependent and break
+                if not all (juncture):
+                    self._organize ([child.tag], runid, targets,
+                                    'promition not possible')
+                    continue
+
+                # 5: promote decendent state vectors
+                outputs = dawgie.db.promote (juncture, runid)
+                # 6: add decendent to todo list
+                self._todo.append (child, runid, outputs)
+                pass
         elif not dawgie.context.allow_promotion: self.clear()
         return
 
     def more (self)->bool: return 0 < len (self._todo)
+
+    @property
+    def organize (self): return self._organize
+
+    @organize.setter
+    def organize (self, organizer): self._organize = organizer
 
     def todo (self,
               original:dawgie.pl.dag.Node=None,
@@ -97,3 +150,33 @@ class Engine:
                                 filter (lambda t:not t[1], values)]))
         return
     pass
+
+def _is_scheduled (ignore:dawgie.pl.dag.Node,
+                   node:dawgie.pl.dag.Node,
+                   targets:[str])->bool:
+    result = any (targets.issubset (node.get ('do')),
+                  targets.issubset (node.get ('doing')),
+                  targets.issubset (node.get ('todo')))
+
+    if not result:
+        for parent in node.get ('parents'):
+            if parent == ignore: continue
+            result |= _is_scheduled (ignore, parent, targets)
+            pass
+        pass
+    return result
+
+def _translate (nodes:[dawgie.pl.dag.Node])->[dawgie.db.REF]:
+    result = []
+    for n in nodes:
+        tn,an,sn,vn = n.tag.split('.')
+        t = n.get ('factory')(tn, -1)
+        a = n.get ('alg')
+        s = a.sv_as_dict()[sn]
+        v = s[vn]
+        result.append (dawgie.db.REF(tid=dawgie.db.ID(tn, t),
+                                     aid=dawgie.db.ID(an, a),
+                                     sid=dawgie.db.ID(sn, s),
+                                     vid=dawgie.db.ID(vn, v)))
+        pass
+    return result

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -136,7 +136,15 @@ class Engine:
     def organize (self): return self._organize
 
     @organize.setter
-    def organize (self, organizer): self._organize = organizer
+    def organize (self, organizer):
+        '''a function used to organize the work to be done
+
+        Should have the same arguments as dawgie.pl.schedule.organize.
+        In fact, the default behavior of the pipeline is to use
+        dawgie.pl.schedule.organize
+        '''
+        self._organize = organizer
+        return
 
     def todo (self,
               original:dawgie.pl.dag.Node=None,

--- a/Python/dawgie/pl/promotion.py
+++ b/Python/dawgie/pl/promotion.py
@@ -108,14 +108,14 @@ class Engine:
                 # 2: is the dependent or ancestors are schduled to run already
                 #    or are running
                 #  if yes, then break
+
                 if _is_scheduled (algnode, child, targets): continue
 
                 # 3: find the consistent set of previous inputs for each output
                 #    in this child
-                juncture = [dawgie.db.consistent (_translate (o.get('parents')),
-                                                  _translate ([o])[0],
-                                                  constraints)
-                            for o in outputs]
+                juncture = dawgie.db.consistent (_translate (inputs),
+                                                 _translate (outputs),
+                                                 constraints)
 
                 # 4: are all of the inputs to dependent the same
                 #    if no, schedule dependent and break
@@ -174,7 +174,7 @@ def _translate (nodes:[dawgie.pl.dag.Node])->[dawgie.db.REF]:
         a = n.get ('alg')
         s = a.sv_as_dict()[sn]
         v = s[vn]
-        result.append (dawgie.db.REF(tid=dawgie.db.ID(tn, t),
+        result.append (dawgie.db.REF(tid=dawgie.db.ID(tn, None),
                                      aid=dawgie.db.ID(an, a),
                                      sid=dawgie.db.ID(sn, s),
                                      vid=dawgie.db.ID(vn, v)))

--- a/Python/dawgie/pl/resources.py
+++ b/Python/dawgie/pl/resources.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/resources.py
+++ b/Python/dawgie/pl/resources.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/scan.py
+++ b/Python/dawgie/pl/scan.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/scan.py
+++ b/Python/dawgie/pl/scan.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/schedule.py
+++ b/Python/dawgie/pl/schedule.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/schedule.py
+++ b/Python/dawgie/pl/schedule.py
@@ -141,6 +141,7 @@ def algorithm_tree_view(): return dawgie.pl.schedule.ae.av
 def build (factories, latest, previous):
     log.info ('build() - starting to build DAG')
     dawgie.pl.schedule.ae = dawgie.pl.dag.Construct(factories)
+    promote.at = dawgie.pl.schedule.ae
     dawgie.pl.schedule.que = []
     dawgie.pl.schedule.per = []
     log.info ('build() - computing version differences')

--- a/Python/dawgie/pl/schedule.py
+++ b/Python/dawgie/pl/schedule.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/schedule.py
+++ b/Python/dawgie/pl/schedule.py
@@ -45,6 +45,7 @@ import dawgie
 import dawgie.context
 import dawgie.db
 import dawgie.pl.dag
+import dawgie.pl.promotion
 import dawgie.pl.schedule
 import dawgie.pl.version
 import dawgie.util
@@ -59,6 +60,7 @@ per = []
 suc = []
 
 pipeline_paused = False
+promote = dawgie.pl.promotion.Engine()
 
 class _DelayNotKnowableError(ArithmeticError): pass
 
@@ -227,7 +229,7 @@ def is_paused(): return dawgie.pl.schedule.pipeline_paused
 
 def next_job_batch():
     todo = []
-    if not dawgie.pl.schedule.is_paused():
+    if not (promote() or dawgie.pl.schedule.is_paused()):
         jobs = dict([(job.tag, job) for job in que])
         for job in filter (lambda j:j.get ('todo'), que):
             available = job.get ('todo').copy()
@@ -320,18 +322,18 @@ def tasks():
 
 def unpause(): dawgie.pl.schedule.pipeline_paused = False
 
-def update (value_names:[(str,bool)], original:dawgie.pl.dag.Node, rid:int):
-    log.info ('update() - New values: %s', str(value_names))
+def update (values:[(str,bool)], original:dawgie.pl.dag.Node, rid:int):
+    log.info ('update() - New values: %s', str(values))
     log.info ('update() - Node name: %s', original.tag)
     log.info ('update() - Run ID: %s', str(rid))
 
-    if value_names:
+    if values:
         event = None
         feedbacks = dawgie.pl.schedule.ae.feedbacks
         targets = set()
         task_names = set()
         vns = set()
-        for vn,_isnew in filter (lambda t:t[1], value_names):
+        for vn,_isnew in filter (lambda t:t[1], values):
             target = vn.split('.')[1]
             targets.add (target)
             fvn = '.'.join (vn.split('.')[2:])
@@ -350,7 +352,9 @@ def update (value_names:[(str,bool)], original:dawgie.pl.dag.Node, rid:int):
                 pass
             pass
         organize (sorted (task_names), rid, targets, event)
-        pass
+        promote (values, original, rid)
+    else: log.error('Node %s for run ID %d did not update its state vector',
+                    original.tag, rid)
     return
 
 def view_doing() -> dict:

--- a/Python/dawgie/pl/schedule.py
+++ b/Python/dawgie/pl/schedule.py
@@ -142,6 +142,7 @@ def build (factories, latest, previous):
     log.info ('build() - starting to build DAG')
     dawgie.pl.schedule.ae = dawgie.pl.dag.Construct(factories)
     promote.at = dawgie.pl.schedule.ae
+    promote.orgainize = dawgie.pl.schedule.organize
     dawgie.pl.schedule.que = []
     dawgie.pl.schedule.per = []
     log.info ('build() - computing version differences')

--- a/Python/dawgie/pl/state.dot
+++ b/Python/dawgie/pl/state.dot
@@ -2,7 +2,7 @@ digraph SDP
 {
 /*
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/state.dot
+++ b/Python/dawgie/pl/state.dot
@@ -2,7 +2,7 @@ digraph SDP
 {
 /*
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/state.py
+++ b/Python/dawgie/pl/state.py
@@ -32,7 +32,7 @@ True
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/state.py
+++ b/Python/dawgie/pl/state.py
@@ -32,7 +32,7 @@ True
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/util.py
+++ b/Python/dawgie/pl/util.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/util.py
+++ b/Python/dawgie/pl/util.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/version.py
+++ b/Python/dawgie/pl/version.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/version.py
+++ b/Python/dawgie/pl/version.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/__init__.py
+++ b/Python/dawgie/pl/worker/__init__.py
@@ -4,7 +4,7 @@ dawgie.context.cloud_data = "api-key@https_url@sqs-name@scale-name@cluster-name@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/__init__.py
+++ b/Python/dawgie/pl/worker/__init__.py
@@ -4,7 +4,7 @@ dawgie.context.cloud_data = "api-key@https_url@sqs-name@scale-name@cluster-name@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/__main__.py
+++ b/Python/dawgie/pl/worker/__main__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/__main__.py
+++ b/Python/dawgie/pl/worker/__main__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/aws.py
+++ b/Python/dawgie/pl/worker/aws.py
@@ -4,7 +4,7 @@ dawgie.context.cloud_data = "api-key@https_url@sqs-name@scale-name@cluster-name@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/aws.py
+++ b/Python/dawgie/pl/worker/aws.py
@@ -4,7 +4,7 @@ dawgie.context.cloud_data = "api-key@https_url@sqs-name@scale-name@cluster-name@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/cluster.py
+++ b/Python/dawgie/pl/worker/cluster.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/pl/worker/cluster.py
+++ b/Python/dawgie/pl/worker/cluster.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/security.py
+++ b/Python/dawgie/security.py
@@ -8,7 +8,7 @@ processing.
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/security.py
+++ b/Python/dawgie/security.py
@@ -8,7 +8,7 @@ processing.
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/__init__.py
+++ b/Python/dawgie/tools/__init__.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/__init__.py
+++ b/Python/dawgie/tools/__init__.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/compliant.py
+++ b/Python/dawgie/tools/compliant.py
@@ -3,7 +3,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/compliant.py
+++ b/Python/dawgie/tools/compliant.py
@@ -3,7 +3,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/dag.py
+++ b/Python/dawgie/tools/dag.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/dag.py
+++ b/Python/dawgie/tools/dag.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/detach.py
+++ b/Python/dawgie/tools/detach.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/detach.py
+++ b/Python/dawgie/tools/detach.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/logfile.py
+++ b/Python/dawgie/tools/logfile.py
@@ -3,7 +3,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/logfile.py
+++ b/Python/dawgie/tools/logfile.py
@@ -3,7 +3,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/resources.py
+++ b/Python/dawgie/tools/resources.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/resources.py
+++ b/Python/dawgie/tools/resources.py
@@ -1,6 +1,6 @@
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/submit.py
+++ b/Python/dawgie/tools/submit.py
@@ -3,7 +3,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/submit.py
+++ b/Python/dawgie/tools/submit.py
@@ -3,7 +3,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/trace.py
+++ b/Python/dawgie/tools/trace.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/tools/trace.py
+++ b/Python/dawgie/tools/trace.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/util.py
+++ b/Python/dawgie/util.py
@@ -2,7 +2,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/dawgie/util.py
+++ b/Python/dawgie/util.py
@@ -2,7 +2,7 @@
 
 --
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/__init__.py
+++ b/Test/ae/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/__init__.py
+++ b/Test/ae/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/disk/__init__.py
+++ b/Test/ae/disk/__init__.py
@@ -1,7 +1,7 @@
 '''The algorithm engine for touching the local disk
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/disk/__init__.py
+++ b/Test/ae/disk/__init__.py
@@ -1,7 +1,7 @@
 '''The algorithm engine for touching the local disk
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/disk/bot.py
+++ b/Test/ae/disk/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/disk/bot.py
+++ b/Test/ae/disk/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/feedback/__init__.py
+++ b/Test/ae/feedback/__init__.py
@@ -1,7 +1,7 @@
 '''The algorithm engine for touching the local disk
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/feedback/__init__.py
+++ b/Test/ae/feedback/__init__.py
@@ -1,7 +1,7 @@
 '''The algorithm engine for touching the local disk
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/feedback/bot.py
+++ b/Test/ae/feedback/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/feedback/bot.py
+++ b/Test/ae/feedback/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/network/__init__.py
+++ b/Test/ae/network/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/network/__init__.py
+++ b/Test/ae/network/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/network/bot.py
+++ b/Test/ae/network/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/network/bot.py
+++ b/Test/ae/network/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/noio/__init__.py
+++ b/Test/ae/noio/__init__.py
@@ -1,7 +1,7 @@
 '''The algorithm engine for touching the local disk
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/noio/__init__.py
+++ b/Test/ae/noio/__init__.py
@@ -1,7 +1,7 @@
 '''The algorithm engine for touching the local disk
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/noio/bot.py
+++ b/Test/ae/noio/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/noio/bot.py
+++ b/Test/ae/noio/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/review/__init__.py
+++ b/Test/ae/review/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/review/__init__.py
+++ b/Test/ae/review/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/review/bot.py
+++ b/Test/ae/review/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/ae/review/bot.py
+++ b/Test/ae/review/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/bae/__init__.py
+++ b/Test/bae/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/bae/__init__.py
+++ b/Test/bae/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/bae/network/__init__.py
+++ b/Test/bae/network/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/bae/network/__init__.py
+++ b/Test/bae/network/__init__.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/bae/network/bot.py
+++ b/Test/bae/network/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/bae/network/bot.py
+++ b/Test/bae/network/bot.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_01.py
+++ b/Test/test_01.py
@@ -77,10 +77,11 @@ class Metric(unittest.TestCase):
         m = dawgie._Metric()
         m.measure (Metric._io, (100,))
         s = m.sum()
+        print ('metric:', s)
         # self.assertTrue (1400000 < s.input)
-        self.assertTrue (1400000 < s.output)
-        self.assertTrue (3000 < s.mem)
-        self.assertTrue (0.0 < s.sys)
-        self.assertTrue (0.0 < s.user)
+        self.assertLess (1400000, s.output)
+        self.assertLess (3000, s.mem)
+        self.assertLess (0.0, s.sys)
+        self.assertLess (0.0, s.user)
         return
     pass

--- a/Test/test_01.py
+++ b/Test/test_01.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_01.py
+++ b/Test/test_01.py
@@ -58,7 +58,7 @@ class Metric(unittest.TestCase):
         fid,fn = tempfile.mkstemp()
         os.close (fid)
         for n in range(N):
-            x = numpy.random.rand (1000,1000)
+            x = numpy.random.rand (1200,1200)
             with open (fn, 'bw') as f: pickle.dump (x, f)
             with open (fn, 'br') as f: y = pickle.load (f)
             pass

--- a/Test/test_01.py
+++ b/Test/test_01.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_02.py
+++ b/Test/test_02.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_02.py
+++ b/Test/test_02.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_03.py
+++ b/Test/test_03.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_03.py
+++ b/Test/test_03.py
@@ -77,6 +77,6 @@ class Logger(unittest.TestCase):
         print ('log file:')
         print (text)
         self.assertTrue (text)
-        self.assertTrue (text.find ('%s') < 0)
+        self.assertLess (text.find ('%s') < 0)
         return
     pass

--- a/Test/test_03.py
+++ b/Test/test_03.py
@@ -50,19 +50,28 @@ class Logger(unittest.TestCase):
         unittest.TestCase.__init__(self, *args)
         fid,self.log_path = tempfile.mkstemp()
         os.close(fid)
+        with open (self.log_path, 'tw') as file: file.write ('yup\n')
+        self.aborted = False
         pass
 
+    def _abort (self):
+        self.aborted = True
+        self._stop()
+        return
+
     def _log_msg (self):
-        logging.getLogger (__name__).warning ('some text %s', ', more text')
+        self.mylog.warning ('some text %s', ', more text')
         twisted.internet.reactor.callLater (1, self._stop)
         return
 
     def _start_logger (self):
         dawgie.pl.logger.start (self.log_path, dawgie.context.log_port)
-        handler = dawgie.pl.logger.TwistedHandler\
-                  (host='localhost', port=dawgie.context.log_port)
-        logging.basicConfig (handlers=[handler], level=logging.WARN)
+        self.handler = dawgie.pl.logger.TwistedHandler\
+                       (host='localhost', port=dawgie.context.log_port)
+        logging.basicConfig (level=logging.INFO)
         logging.captureWarnings (True)
+        self.mylog = logging.getLogger (__name__)
+        self.mylog.addHandler (self.handler)
         return
 
     def _stop (self):
@@ -72,11 +81,12 @@ class Logger(unittest.TestCase):
     def test_issue_45(self):
         twisted.internet.reactor.callLater (0, self._start_logger)
         twisted.internet.reactor.callLater (1, self._log_msg)
+        twisted.internet.reactor.callLater (11, self._abort)
         twisted.internet.reactor.run()
+        self.assertFalse (self.aborted)
+        self.assertTrue (os.path.isfile (self.log_path))
         with open (self.log_path, 'rt') as f: text = f.read()
-        print ('log file:')
-        print (text)
         self.assertTrue (text)
-        self.assertLess (text.find ('%s') < 0)
+        self.assertLess (text.find ('%s'), 0)
         return
     pass

--- a/Test/test_03.py
+++ b/Test/test_03.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_04.py
+++ b/Test/test_04.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_04.py
+++ b/Test/test_04.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_05.py
+++ b/Test/test_05.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_05.py
+++ b/Test/test_05.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_06.py
+++ b/Test/test_06.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_06.py
+++ b/Test/test_06.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_07.py
+++ b/Test/test_07.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_07.py
+++ b/Test/test_07.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_08.py
+++ b/Test/test_08.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_08.py
+++ b/Test/test_08.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_09.py
+++ b/Test/test_09.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_09.py
+++ b/Test/test_09.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_10.py
+++ b/Test/test_10.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_10.py
+++ b/Test/test_10.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_11.py
+++ b/Test/test_11.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_11.py
+++ b/Test/test_11.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -1,0 +1,61 @@
+'''
+
+COPYRIGHT:
+Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+U.S. Government sponsorship acknowledged.
+
+All rights reserved.
+
+LICENSE:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of Caltech nor its operating division, the Jet
+Propulsion Laboratory, nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+NTR:
+'''
+
+import dawgie.pl.promotion
+import unittest
+
+class PromotionEngine(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls): cls.promote = dawgie.pl.promotion.Engine()
+
+    def test_call(self):
+        with self.assertLogs ('dawgie.pl.promotion', level=0) as al:
+            more = self.promote ([('a.b.c',True)])
+            pass
+        self.assertFalse (more)
+        print (al.output)
+        self.assertEqual (al.output, ['ERROR:dawgie.pl.promotion:Inconsistent arguments. Ignoring request.'])
+        more = self.promote ([('a.b.c',True)], 'a.b', 1)
+        self.assertFalse (more)
+        more = self.promote ([('a.b.c',True), ('a.b.d',False)], 'a.b', 1)
+        self.assertTrue (more)
+        self.promote.clear()
+        self.assertFalse (self.promote.more())
+        return
+    pass

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -59,6 +59,18 @@ class PromotionEngine(unittest.TestCase):
                                        'a.b', 1))
         self.promote.clear()
         self.assertFalse (self.promote.more())
+        return
+
+    def test_do_allows(self):
+        '''test allow to run conditions
+        1. dawgie.context.allow_promotion is False
+        2. No AE
+        3. No organizer
+        '''
+        self.promote.clear()
+        self.assertFalse (self.promote.more())
+        with self.assertRaises (ValueError): self.promote.do()
+        self.promote.ae = 1
         with self.assertRaises (ValueError): self.promote.do()
         ac = dawgie.context.allow_promotion
         dawgie.context.allow_promotion = False

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -38,14 +38,66 @@ NTR:
 '''
 
 import dawgie.context
+import dawgie.db.test
 import dawgie.pl.promotion
 import unittest
+
+class SVMock(dawgie.StateVector):
+    def __init__(self, base):
+        dawgie.StateVector.__init__(self)
+        self.update (base)
+        self._version_ = dawgie.VERSION(2,2,2)
+        return
+    pass
+class VMock(dawgie.Value):
+    def __init__(self):
+        dawgie.Version.__init__(self)
+        self._version_ = (3,3,3)
+        return
+    pass
+class AlgMock(dawgie.Algorithm):
+    def __init__(self):
+        dawgie.Algorithm.__init__(self)
+        self._version_ = (1,1,1)
+        return
+    def sv_as_dict(self): return {'d':SVMock({'e':VMock()}),
+                                  'g':SVMock({'h':VMock()})}
+    pass
 
 class PromotionEngine(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.promote = dawgie.pl.promotion.Engine()
         dawgie.context.allow_promotion = True
+        dawgie.context.db_impl = 'test'
+        return
+
+    def mock_consistent (self, inputs:[dawgie.db.REF], outputs:[dawgie.db.REF],
+                         target_name:str)->():
+        if self.mock_behavior[0]:  # return a valid juncture
+            return ((1,2,3,4,5), (6,7,8,9,0))
+        return ()
+
+    def mock_organize (self, task_names, runid=None, targets=None, event=None):
+        self.assertListEqual (['b.f.g.h'], task_names)
+        self.assertEqual (10101, runid)
+        self.assertEqual (['a'], list(targets))
+
+        if not self.mock_behavior[0]:
+            self.assertEqual ('promotion not possible', event)
+        elif not self.mock_behavior[1]:
+            self.assertEqual ('promotion failed to insert', event)
+        else: self.assertEqual ('path not possible', event)
+        return
+
+    def mock_promote (self, juncture:(), runid:int):
+        self.assertTupleEqual (((1,2,3,4,5), (6,7,8,9,0)), juncture)
+        return self.mock_behavior[1]
+
+    def setUp(self):
+        self.mock_behavior = [False, False]
+        setattr (dawgie.db.test, 'consistent', self.mock_consistent)
+        setattr (dawgie.db.test, 'promote', self.mock_promote)
         return
 
     def test_ae(self):
@@ -78,6 +130,8 @@ class PromotionEngine(unittest.TestCase):
         '''
         self.promote.clear()
         self.assertFalse (self.promote.more())
+        self.promote.ae = None
+        self.promote.organize = None
         with self.assertRaises (ValueError): self.promote.do()
         self.promote.ae = 1
         with self.assertRaises (ValueError): self.promote.do()
@@ -90,6 +144,37 @@ class PromotionEngine(unittest.TestCase):
         return
 
     def test_do(self):
+        ct = 'b.c.d.e'
+        root = dawgie.pl.dag.Node('b.c',
+                                  attrib={'do':[],
+                                          'doing':[],
+                                          'parents':[],
+                                          'todo':[]})
+        node = dawgie.pl.dag.Node('b.c.d.e',
+                                  attrib={'alg':AlgMock(),
+                                          'do':[],
+                                          'doing':[],
+                                          'parents':[],
+                                          'todo':[]})
+        node = dawgie.pl.dag.Node('b.f.g.h',
+                                  attrib={'alg':AlgMock(),
+                                          'do':[],
+                                          'doing':[],
+                                          'parents':[node],
+                                          'todo':[]})
+        root.add (node)
+        self.mock_behavior[0] = False
+        self.mock_behavior[1] = False
+        self.promote.organize = self.mock_organize
+        self.promote.ae = {'b.f.g.h':[node]}
+        self.assertTrue (dawgie.context.allow_promotion)
+        self.promote.todo (root, 10101, [('1.a.'+ct, False)])
+        self.assertTrue (self.promote.more())
+        self.promote.do()
+        self.mock_behavior[0] = True
+        self.promote.do()
+        self.mock_behavior[1] = True
+        self.promote.do()
         return
 
     def test_more(self):

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -59,6 +59,7 @@ class PromotionEngine(unittest.TestCase):
                                        'a.b', 1))
         self.promote.clear()
         self.assertFalse (self.promote.more())
+        with self.assertRaises (ValueError): self.promote.do()
         ac = dawgie.context.allow_promotion
         dawgie.context.allow_promotion = False
         self.assertTrue (self.promote ([('a.b.c',True), ('a.b.d',False)],

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -37,25 +37,33 @@ POSSIBILITY OF SUCH DAMAGE.
 NTR:
 '''
 
+import dawgie.context
 import dawgie.pl.promotion
 import unittest
 
 class PromotionEngine(unittest.TestCase):
     @classmethod
-    def setUpClass(cls): cls.promote = dawgie.pl.promotion.Engine()
+    def setUpClass(cls):
+        cls.promote = dawgie.pl.promotion.Engine()
+        dawgie.context.allow_promotion = True
+        return
 
     def test_call(self):
         with self.assertLogs ('dawgie.pl.promotion', level=0) as al:
-            more = self.promote ([('a.b.c',True)])
+            self.assertFalse (self.promote ([('a.b.c',True)]))
             pass
-        self.assertFalse (more)
         print (al.output)
         self.assertEqual (al.output, ['ERROR:dawgie.pl.promotion:Inconsistent arguments. Ignoring request.'])
-        more = self.promote ([('a.b.c',True)], 'a.b', 1)
-        self.assertFalse (more)
-        more = self.promote ([('a.b.c',True), ('a.b.d',False)], 'a.b', 1)
-        self.assertTrue (more)
+        self.assertFalse (self.promote ([('a.b.c',True)], 'a.b', 1))
+        self.assertTrue (self.promote ([('a.b.c',True), ('a.b.d',False)],
+                                       'a.b', 1))
         self.promote.clear()
         self.assertFalse (self.promote.more())
+        ac = dawgie.context.allow_promotion
+        dawgie.context.allow_promotion = False
+        self.assertTrue (self.promote ([('a.b.c',True), ('a.b.d',False)],
+                                       'a.b', 1))
+        self.assertFalse (self.promote.do())
+        dawgie.context.allow_promotion = ac
         return
     pass

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_12.py
+++ b/Test/test_12.py
@@ -48,6 +48,15 @@ class PromotionEngine(unittest.TestCase):
         dawgie.context.allow_promotion = True
         return
 
+    def test_ae(self):
+        ae = self.promote.ae
+        self.promote.ae = None
+        self.assertTrue (self.promote.ae is None)
+        self.promote.ae = 1
+        self.assertEqual (1, self.promote.ae)
+        self.promote.ae = ae
+        return
+
     def test_call(self):
         with self.assertLogs ('dawgie.pl.promotion', level=0) as al:
             self.assertFalse (self.promote ([('a.b.c',True)]))
@@ -78,5 +87,39 @@ class PromotionEngine(unittest.TestCase):
                                        'a.b', 1))
         self.assertFalse (self.promote.do())
         dawgie.context.allow_promotion = ac
+        return
+
+    def test_do(self):
+        return
+
+    def test_more(self):
+        self.promote.clear()
+        self.assertFalse (self.promote.more())
+        self.promote._todo = [1]
+        self.assertTrue (self.promote.more())
+        self.promote.clear()
+        self.assertFalse (self.promote.more())
+        return
+
+    def test_organize(self):
+        organize = self.promote.organize
+        self.promote.organize = None
+        self.assertTrue (self.promote.organize is None)
+        self.promote.organize = 1
+        self.assertEqual (1, self.promote.organize)
+        self.promote.organize = organize
+        return
+
+    def test_todo(self):
+        self.promote.clear()
+        self.assertFalse (self.promote.more())
+        self.promote.todo (values=[('a',True),('b',True),('c',True)])
+        self.assertFalse (self.promote.more())
+        self.promote.clear()
+        self.assertFalse (self.promote.more())
+        self.promote.todo (values=[('a',True),('b',False),('c',True)])
+        self.assertTrue (self.promote.more())
+        self.promote.clear()
+        self.assertFalse (self.promote.more())
         return
     pass

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -1,4 +1,4 @@
-'''
+''' show that add DBs behave the same
 
 COPYRIGHT:
 Copyright (c) 2015-2021, California Institute of Technology ("Caltech").

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -1,4 +1,4 @@
-''' show that add DBs behave the same
+''' show that all DBs behave the same
 
 COPYRIGHT:
 Copyright (c) 2015-2021, California Institute of Technology ("Caltech").

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -394,7 +394,7 @@ class Post(DB,unittest.TestCase):
         os.mkdir (os.path.join (cls.root, 'dbs'))
         os.mkdir (os.path.join (cls.root, 'logs'))
         os.mkdir (os.path.join (cls.root, 'stg'))
-        dawgie.context.db_host = 'postgres'
+        dawgie.context.db_host = 'cit_postgres'
         dawgie.context.db_impl = 'post'
         dawgie.context.db_name = 'testspace'
         dawgie.context.db_path = 'tester:password'

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -37,9 +37,6 @@ POSSIBILITY OF SUCH DAMAGE.
 NTR:
 '''
 
-# Save the actual work for another day, but this shows how to write one set
-# of tests in DB then test each instance by two other objects that extend it.
-
 import dawgie
 import dawgie.db.testdata
 import dawgie.context
@@ -47,6 +44,9 @@ import os
 import shutil
 import tempfile
 import unittest
+
+# Save the actual work for another day, but this shows how to write one set
+# of tests in DB then test each instance by two other objects that extend it.
 
 class DB:
     @classmethod
@@ -129,7 +129,14 @@ class DB:
         return
     pass
 
-@unittest.skip ('no generic way to build postgres database')
+# to test postgres:
+#   docker pull postgres:13.3
+#   docker network create cit
+#   docker run --detach --env POSTGRES_PASSWORD=password --env POSTGRES_USER=tester --name postgres --network cit --rm  postgres:13.3
+#   docker exec -i postgres createdb -U tester testspace
+#   CIT_NETWORK=cit .ci/check_03.sh ; git checkout .ci/status.txt
+#   docker network rm cit
+@unittest.skip ('no automatic way to build postgres database')
 class Post(DB,unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -138,11 +145,15 @@ class Post(DB,unittest.TestCase):
         os.mkdir (os.path.join (cls.root, 'dbs'))
         os.mkdir (os.path.join (cls.root, 'logs'))
         os.mkdir (os.path.join (cls.root, 'stg'))
+        dawgie.context.db_host = 'postgres'
         dawgie.context.db_impl = 'post'
+        dawgie.context.db_name = 'testspace'
+        dawgie.context.db_path = 'tester:password'
+        dawgie.context.db_port = 5432
         dawgie.context.data_dbs = os.path.join (cls.root, 'dbs')
         dawgie.context.data_log = os.path.join (cls.root, 'logs')
         dawgie.context.data_stg = os.path.join (cls.root, 'stg')
-        dawgie.db_rotate_path = dawgie.context.db_path
+        dawgie.db_rotate_path = os.path.join (cls.root, 'db')
         DB.setup()
         return
 
@@ -162,6 +173,7 @@ class Shelf(DB,unittest.TestCase):
         os.mkdir (os.path.join (cls.root, 'logs'))
         os.mkdir (os.path.join (cls.root, 'stg'))
         dawgie.context.db_impl = 'shelf'
+        dawgie.context.db_name = 'testspace'
         dawgie.context.db_path = os.path.join (cls.root, 'db')
         dawgie.context.data_dbs = os.path.join (cls.root, 'dbs')
         dawgie.context.data_log = os.path.join (cls.root, 'logs')

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -1,0 +1,70 @@
+'''
+
+COPYRIGHT:
+Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+U.S. Government sponsorship acknowledged.
+
+All rights reserved.
+
+LICENSE:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of Caltech nor its operating division, the Jet
+Propulsion Laboratory, nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+NTR:
+'''
+
+## Save the actual work for another day, but this shows how to write one set
+## of tests in DB then test each instance by two other objects that extend it.
+
+import dawgie.context
+import unittest
+
+class DB:
+    @classmethod
+    def setup(cls):
+        return
+
+    def test_archive(self):
+        self.assertTrue (True)
+        return
+    pass
+
+class Post(DB,unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        dawgie.context.db_impl = 'post'
+        DB.setup()
+        return
+    pass
+
+class Shelf(DB,unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        dawgie.context.db_impl = 'shelf'
+        DB.setup()
+        return
+    pass

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -1,7 +1,7 @@
 ''' show that all DBs behave the same
 
 COPYRIGHT:
-Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -53,6 +53,7 @@ class DB:
         return
     pass
 
+@unittest.skip ('no generic way to build postgres database')
 class Post(DB,unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -61,6 +62,7 @@ class Post(DB,unittest.TestCase):
         return
     pass
 
+@unittest.skip ('current shelf is not a true replacement for postgres')
 class Shelf(DB,unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -37,8 +37,8 @@ POSSIBILITY OF SUCH DAMAGE.
 NTR:
 '''
 
-## Save the actual work for another day, but this shows how to write one set
-## of tests in DB then test each instance by two other objects that extend it.
+# Save the actual work for another day, but this shows how to write one set
+# of tests in DB then test each instance by two other objects that extend it.
 
 import dawgie.context
 import unittest

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -1,7 +1,7 @@
 '''
 
 COPYRIGHT:
-Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -40,16 +40,92 @@ NTR:
 # Save the actual work for another day, but this shows how to write one set
 # of tests in DB then test each instance by two other objects that extend it.
 
+import dawgie
+import dawgie.db.testdata
 import dawgie.context
 import unittest
 
 class DB:
     @classmethod
     def setup(cls):
+        dawgie.db.open()
+        for tsk,alg,sv,vn,v in dawgie.db.testdata.KNOWNS:
+            dawgie.db.update (tsk, alg, sv, vn, v)
+            pass
+        for tgt,tsk,alg in dawgie.db.testdata.DATASETS:
+            dawgie.db.connect (alg, tsk, tgt).update()
+            pass
+        for tsk,alg in dawgie.db.testdata.ASPECTS:
+            dawgie.db.gather (alg, tsk).ds().update()
+            pass
+        for tsk,alg in dawgie.db.testdata.TIMELINES:
+            dawgie.db.retreat (alg, tsk).ds().update()
+            pass
+        for juncture in dawgie.db.testdata.testdata.JUNCTURES:
+            dawgie.db.promote (juncture)
+            pass
+        dawgie.db.close()
+        return
+
+    def test__prime_keys(self):
+        return
+
+    def test__prime_values(self):
         return
 
     def test_archive(self):
         self.assertTrue (True)
+        return
+
+    def test_close(self):
+        return
+
+    def test_connect(self):
+        return
+
+    def test_consistent(self):
+        return
+
+    def test_copy(self):
+        return
+
+    def test_gather(self):
+        return
+
+    def test_metrics(self):
+        return
+
+    def test_next(self):
+        return
+
+    def test_open(self):
+        return
+
+    def test_promote(self):
+        return
+
+    def test_remove(self):
+        return
+
+    def test_reopen(self):
+        return
+
+    def test_retreat(self):
+        return
+
+    def test_targets(self):
+        return
+
+    def test_trace(self):
+        return
+
+    def test_update (self):
+        return
+
+    def test_versions(self):
+        return
+
+    def test_locks(self):
         return
     pass
 

--- a/Test/test_13.py
+++ b/Test/test_13.py
@@ -276,7 +276,7 @@ class DB:
 # notes:
 #   takes about 5 minutes to load the database
 #   once loaded it can simply be re-used (no reason to dump and start again)
-#unittest.skip ('no automatic way to build postgres database')
+# unittest.skip ('no automatic way to build postgres database')
 class Post(DB,unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2022, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # COPYRIGHT:
-# Copyright (c) 2015-2020, California Institute of Technology ("Caltech").
+# Copyright (c) 2015-2021, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.


### PR DESCRIPTION
Closes #139 

Includes extensions to the DB to support promotion. Because the shelf DB does not fully implement version support it is not capable of supporting promotion.

The promotion engine is implemented. The big realization during the implementation is that it should be the default scheduler in the future.