### PR TITLE
Update post2shelve.py

### DIFF
--- a/Python/dawgie/db/tools/post2shelve.py
+++ b/Python/dawgie/db/tools/post2shelve.py
@@ -104,7 +104,7 @@ def convert_prime_db(conn, fn, data, all_vers:bool):
                 'alg_ID = ANY(%s) AND sv_ID = ANY(%s) AND val_ID = ANY(%s);',
                 (list(data['target']), list(data['task']), list(data['alg']),
                  list(data['state']), list(data['value'])))
-    for rid,tnid,tid,aid,svid,vid,bn in cur.fetchall():
+    for rid,tnid,tid,aid,svid,vid,bn in sorted(cur.fetchall(), key=lambda t:t[0]):
         k = (rid if all_vers else 1,
              data['target'][tnid],
              data['task'][tid],


### PR DESCRIPTION
Closes #219 

Turns out that post2shelve is selecting a random RID because they are not required to come back in any order. So, sort, then write. Now if there is more than one RID for all the selections, only the highest one will be recorded as RID 1.