### PR TITLE
266: repair how dawgie uses git

### DIFF
--- a/Python/dawgie/context.py
+++ b/Python/dawgie/context.py
@@ -70,6 +70,15 @@ class PortOffset(enum.Enum):
 ae_base_path = os.environ.get('DAWGIE_AE_BASE_PATH', '/proj/src/ae')
 ae_base_package = os.environ.get('DAWGIE_AE_BASE_PACKAGE', 'ae')
 
+ae_repository_remote = os.environ.get('DAWGIE_AE_REPO_REMOTE', 'origin')
+ae_repository_branch_ops = os.environ.get('DAWGIE_AE_REPO_BRANCH_OPS', 'ops')
+ae_repository_branch_stable = os.environ.get(
+    'DAWGIE_AE_REPO_BRANCH_STABLE', 'main'
+)
+ae_repository_branch_test = os.environ.get(
+    'DAWGIE_AE_REPO_BRANCH_TEST', 'opstest'
+)
+
 allow_promotion = os.environ.get('DAWGIE_PROMOTION', 'false').lower() in 'true'
 
 cfe_port = int(
@@ -173,6 +182,30 @@ def add_arguments(ap):
         default=ae_base_package,
         required=False,
         help='the package prefix for the AE [%(default)s]',
+    )
+    ap.add_argument(
+        '--context-ae-repo-remote',
+        default=ae_repository_remote,
+        required=False,
+        help='the git remote to pull changes from when a changeset is submitted [%(default)s]',
+    )
+    ap.add_argument(
+        '--context-ae-repo-branch-ops',
+        default=ae_repository_branch_ops,
+        required=False,
+        help='the local and transitory git branch to use for operations[%(default)s]',
+    )
+    ap.add_argument(
+        '--context-ae-repo-branch-stable',
+        default=ae_repository_branch_stable,
+        required=False,
+        help='the git branch to pull changes from when they are stable enough for operations [%(default)s]',
+    )
+    ap.add_argument(
+        '--context-ae-repo-branch-test',
+        default=ae_repository_branch_test,
+        required=False,
+        help='the local and transitory git branch for doing dawgie.tools.compliant [%(default)s]',
     )
     ap.add_argument(
         '--context-allow-promotion',
@@ -448,6 +481,12 @@ def override(args):
 
     dawgie.context.ae_base_path = args.context_ae_dir
     dawgie.context.ae_base_package = args.context_ae_pkg
+    dawgie.context.ae_repository_remote = args.context_ae_repo_remote
+    dawgie.context.ae_repository_branch_ops = args.context_ae_repo_branch_ops
+    dawgie.context.ae_repository_branch_stable = (
+        args.context_ae_repo_branch_stable
+    )
+    dawgie.context.ae_repository_branch_test = args.context_ae_repo_branch_test
     dawgie.context.allow_promotion = args.context_allow_promotion
     dawgie.context.cfe_port = args.context_cfe_port
     dawgie.context.cloud_data = args.context_cloud_data

--- a/Python/dawgie/pl/__main__.py
+++ b/Python/dawgie/pl/__main__.py
@@ -43,7 +43,6 @@ NTR:
 import argparse
 import dawgie.context
 import dawgie.pl.state
-import dawgie.tools.submit
 import dawgie.util
 import logging
 import matplotlib; matplotlib.use("Agg")  # fmt: skip # noqa: E702 # pylint: disable=multiple-statements
@@ -104,13 +103,6 @@ ap.add_argument(
     required=False,
     type=int,
     help='server port number for the display [%(default)s]',
-)
-ap.add_argument(
-    '-r',
-    '--repo-dir',
-    default=dawgie.tools.submit.REPO_DIR,
-    required=False,
-    help='set the pre_ops repo directory where you want to do the merging [%(default)s]',
 )
 dawgie.context.add_arguments(ap)
 args = ap.parse_args()

--- a/Python/dawgie/pl/state.py
+++ b/Python/dawgie/pl/state.py
@@ -317,7 +317,6 @@ class FSM:
         else:
             log.info("Jump into the time machine. Do the reload Rollback.")
             dawgie.db.close()
-            dawgie.tools.submit.update_ops()
             dawgie.context.git_rev = dawgie.context._rev()
             self.time_machine.reload()
             pass


### PR DESCRIPTION
DAWGIE wants to use 3 branches. The first branch is the stable branch to pull changesets from. It does this via a simple pull and will jump to the head of the stable branch.

The second branch is an ops testing branch. When a submit is requested, the stable branch is updated and a test branch created at the head. It then does dawgie.tools.compliant.

Once the test branch has shown that stable HEAD is dawgie.tools.compliant, it deletes the current ops branch and then creates it again (the third branch) at the new stable HEAD. It is best to have this branch created before startng DAWGIE.

Moved some useful parameters from dawgie.tools.submit to dawgie.context for consistency and ease of use. In moving them, gave them environment names and CLI arguments.