### PR TITLE
319: pydot deprecation warnings

### DIFF
--- a/Python/dawgie/pl/state.py
+++ b/Python/dawgie/pl/state.py
@@ -179,7 +179,7 @@ class FSM:
             os.path.join(
                 os.path.abspath(os.path.dirname(__file__)), self.dot_file_name
             )
-        )
+        )[0]
         idir = os.path.abspath(
             os.path.join(dawgie.context.fe_path, 'images/svg')
         )

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,13 +1,13 @@
 bokeh>=1.2
 boto3>=1.7.80
 cryptography>=2.1.4
-dawgie-pydot3==1.0.11
 Deprecated
 GitPython>=2.1.11
 matplotlib>=2.1.1
 progressbar2
 psycopg>=3.2.12
 psycopg-binary>=3.2.12
+pydot
 pyparsing>=2.4.7
 pyOpenSSL>=19.1.0
 python-gnupg==0.4.9


### PR DESCRIPTION
Updated to the latest pydot and changed dawgie.pl.state to accommodate, but the deprecation warnings no longer appear. However, they do appear in interactive sessions. Will keep #319 open to fix the pyparsing deprecated warnings when they show back up.