### PR TITLE
Urgent scan fix

### DIFF
--- a/Python/dawgie/pl/scan.py
+++ b/Python/dawgie/pl/scan.py
@@ -52,7 +52,7 @@ REGISTRY = {}
 
 
 def _content(f: dawgie.Factories, fn: str, fs: dawgie.base.Factories) -> []:
-    try: 
+    try:
         if f == dawgie.Factories.events:
             something = getattr(fs, fn)()
         else:
@@ -131,7 +131,7 @@ def advanced_factories(ae, pkg):
                 )
             elif _content(f, fn, fs):
                 setattr(m, fn, getattr(fs, fn))
-            else:
+            elif hasattr(m, fn):
                 delattr(m, fn)
             if hasattr(m, fn):
                 factories[f].append(getattr(m, fn))


### PR DESCRIPTION
- urgent patch

Seems the search for metadata is not as robust as one would like. Adapted to a different form and let workflow check that it works with the tests system as well.

It now handles factories that are there as placeholders but never get used by deleting the factory in monkey patch form.