### PR TITLE
update API for invalid

### DIFF
--- a/Python/dawgie/fe/api/README.md
+++ b/Python/dawgie/fe/api/README.md
@@ -53,6 +53,7 @@ An example of how to use the endpoint with curl including its output. All exampl
 - [`/api/schedule/events`](#/api/schedule/events-get)
 - [`/api/schedule/failed`](#/api/schedule/failed-get)
 - [`/api/schedule/in-progress`](#/api/schedule/in-progress-get)
+- [`/api/schedule/invalid`](#/api/schedule/invalid-get)
 - [`/api/schedule/stats`](#/api/schedule/stats-get)
 - [`/api/schedule/succeeded`](#/api/schedule/succeeded-get)
 - [`/api/schedule/to-do`](#/api/schedule/to-do-get)
@@ -664,6 +665,65 @@ curl -ksX GET 'https://localhost:8080/api/schedule/in-progress' | jq
 {
   "content": [
     "network.analyzer[__all__] duration: 00:00:00"
+  ],
+  "message": "",
+  "status": "success"
+}
+```
+### `/api/schedule/invalid` (GET)
+#### Description
+List of tasks that completed successfully.
+#### Parameters
+- _index_ : 0 is the first index and default when not provided representing the most current task that ran successfully but failed to generate data.
+- _limit_ : number of invalid tasks to return and if not given all of them.
+#### Content
+A JSON object with information about the runid, target, task, revision of the AE, and timing. With respect to timing, can only count on scheduled, started, and completed. The `load_*` and `start_*` identify when the algorthing name has its input data being loaded (`load_*`) vs when run() (`start_*`) is called.
+#### Example
+```
+curl -ksX GET 'https://localhost:8080/api/schedule/invalid?index=0&limit=3' | jq
+```
+```
+{
+  "content": [
+    {
+      "timing": {
+        "scheduled": "2026-01-25 22:02:42.648946+00:00",
+        "started": "2026-01-25 22:02:42.940578+00:00",
+        "load_output": "2026-01-25 22:02:42.943931+00:00",
+        "start_output": "2026-01-25 22:02:43.264260+00:00",
+        "completed": "2026-01-25 22:02:43.610183+00:00"
+      },
+      "runid": 21,
+      "target": "/tmp/tmpz5ujy6cu",
+      "task": "feedback.output",
+      "changeset": "FAKE-VERSION-FOR-EXERCISE"
+    },
+    {
+      "timing": {
+        "scheduled": "2026-01-25 22:01:42.623334+00:00",
+        "started": "2026-01-25 22:02:37.955120+00:00",
+        "load_control": "2026-01-25 22:02:37.958406+00:00",
+        "start_control": "2026-01-25 22:02:38.744276+00:00",
+        "completed": "2026-01-25 22:02:39.183357+00:00"
+      },
+      "runid": 20,
+      "target": "/tmp/tmpz5ujy6cu",
+      "task": "feedback.control",
+      "changeset": "FAKE-VERSION-FOR-EXERCISE"
+    },
+    {
+      "timing": {
+        "scheduled": "2026-01-25 22:01:37.622043+00:00",
+        "started": "2026-01-25 22:01:37.911937+00:00",
+        "load_sum": "2026-01-25 22:01:37.915247+00:00",
+        "start_sum": "2026-01-25 22:01:38.593958+00:00",
+        "completed": "2026-01-25 22:01:38.940090+00:00"
+      },
+      "runid": 20,
+      "target": "/tmp/tmpz5ujy6cu",
+      "task": "feedback.sum",
+      "changeset": "FAKE-VERSION-FOR-EXERCISE"
+    }
   ],
   "message": "",
   "status": "success"

--- a/Python/dawgie/fe/api/__init__.py
+++ b/Python/dawgie/fe/api/__init__.py
@@ -108,13 +108,13 @@ def df_model_statistics(node_name: str):
         return build_return_object({'status': 'scheduled'})
     matched = []
     for known in dawgie.pl.logger.chronicle.find(
-        after=dawgie.context.boot_time, succeeded=False
+        after=dawgie.context.boot_time, status='failed'
     ):
         if known['task'] == node_name:
             known['status'] = 'failed'
             matched.append(known)
     for known in dawgie.pl.logger.chronicle.find(
-        after=dawgie.context.boot_time, succeeded=True
+        after=dawgie.context.boot_time, status='success'
     ):
         if known['task'] == node_name:
             known['status'] = 'succeeded'
@@ -186,6 +186,7 @@ DynamicContent(schedule.doing, '/api/schedule/doing')
 DynamicContent(schedule.events, '/api/schedule/events')
 DynamicContent(schedule.failed, '/api/schedule/failed')
 DynamicContent(schedule.inprogress, '/api/schedule/in-progress')
+DynamicContent(schedule.invalid, '/api/schedule/invalid')
 DynamicContent(schedule.stats, '/api/schedule/stats')
 DynamicContent(schedule.succeeded, '/api/schedule/succeeded')
 DynamicContent(schedule.todo, '/api/schedule/to-do')

--- a/Python/dawgie/fe/api/__init__.py
+++ b/Python/dawgie/fe/api/__init__.py
@@ -108,7 +108,7 @@ def df_model_statistics(node_name: str):
         return build_return_object({'status': 'scheduled'})
     matched = []
     for known in dawgie.pl.logger.chronicle.find(
-        after=dawgie.context.boot_time, status='failed'
+        after=dawgie.context.boot_time, status='failure'
     ):
         if known['task'] == node_name:
             known['status'] = 'failed'

--- a/Python/dawgie/fe/api/schedule.py
+++ b/Python/dawgie/fe/api/schedule.py
@@ -90,7 +90,7 @@ def failed(
     limit = int(limit[0]) if limit else None
     return build_return_object(
         dawgie.pl.logger.chronicle.find(
-            before=before, limit=limit, status='failed'
+            before=before, limit=limit, status='failure'
         )
     )
 

--- a/Python/dawgie/fe/api/schedule.py
+++ b/Python/dawgie/fe/api/schedule.py
@@ -90,7 +90,7 @@ def failed(
     limit = int(limit[0]) if limit else None
     return build_return_object(
         dawgie.pl.logger.chronicle.find(
-            before=before, limit=limit, succeeded=False
+            before=before, limit=limit, status='failed'
         )
     )
 
@@ -98,6 +98,24 @@ def failed(
 def inprogress(index: int = 0, limit: int = None):
     index, _limit, term = _legacy_arg_fixer(index, limit)
     return build_return_object(dawgie.pl.farm.crew()['busy'][index:term])
+
+
+def invalid(
+    after: [str] = None,
+    before: [str] = None,
+    index: [int] = None,
+    limit: [int] = None,
+):
+    if index is not None:
+        build_return_object(None, Status.FAILURE, 'index has been deprecated')
+    after = datetime.fromisoformat(after[0]) if after else None
+    before = datetime.fromisoformat(before[0]) if before else None
+    limit = int(limit[0]) if limit else None
+    return build_return_object(
+        dawgie.pl.logger.chronicle.find(
+            before=before, limit=limit, status='invalid'
+        )
+    )
 
 
 def stats():
@@ -134,7 +152,7 @@ def succeeded(
     limit = int(limit[0]) if limit else None
     return build_return_object(
         dawgie.pl.logger.chronicle.find(
-            before=before, limit=limit, succeeded=True
+            before=before, limit=limit, status='success'
         )
     )
 

--- a/Python/dawgie/pl/logger/chronicle.py
+++ b/Python/dawgie/pl/logger/chronicle.py
@@ -44,15 +44,14 @@ import os
 from datetime import UTC, datetime, timedelta
 
 
-def _load(after: datetime, before: datetime, journal: str, succeeded: bool):
+def _load(after: datetime, before: datetime, journal: str, status: str):
     entries = []
-    status = 'success' if succeeded else 'failure'
     for fn in filter(lambda fn: fn.endswith('.json'), os.listdir(journal)):
         jsonfile = os.path.join(journal, fn)
         with open(jsonfile, 'rt', encoding='utf-8') as file:
             for entry in json.load(file):
                 completed = datetime.fromisoformat(entry['timing']['completed'])
-                if after < completed < before and entry['status'] == status:
+                if after < completed < before and entry['status'] in status:
                     entries.append(entry)
     entries.sort(key=_most_recent_first, reverse=True)
     return entries
@@ -107,9 +106,9 @@ def find(
     after: datetime = None,
     before: datetime = None,
     limit: int = None,
-    succeeded: bool = True,
+    status: str = 'success',
 ):
-    '''Find the failed/succeeded tasks between two dates to a limit
+    '''Find the failed/invalid/succeeded tasks between two dates to a limit
 
     after - the date time the entries completion time should be after
     before - the date time the entries completion time should be before
@@ -149,7 +148,7 @@ def find(
             if os.path.isdir(journal):
                 journal = os.path.join(journal, f'{before.day:02d}')
                 if os.path.isdir(journal):
-                    entries.extend(_load(after, before, journal, succeeded))
+                    entries.extend(_load(after, before, journal, status))
                 before = before - oneday
             else:
                 before = (

--- a/Test/test_03.py
+++ b/Test/test_03.py
@@ -148,7 +148,7 @@ class Chronicles(unittest.TestCase):
         )
         self.assertEqual(7, len(entries))
         entries = dawgie.pl.logger.chronicle.find(
-            after=datetime(2017, 7, 1, tzinfo=UTC), succeeded=False
+            after=datetime(2017, 7, 1, tzinfo=UTC), status='failed'
         )
         self.assertEqual(6, len(entries))
         entries = dawgie.pl.logger.chronicle.find(before=datetime.now(UTC))
@@ -163,7 +163,7 @@ class Chronicles(unittest.TestCase):
         entries = dawgie.pl.logger.chronicle.find(
             after=datetime(2017, 1, 1, tzinfo=UTC),
             before=datetime(2018, 1, 1, tzinfo=UTC),
-            succeeded=False,
+            status='failed',
         )
         self.assertEqual(14, len(entries))
         entries = dawgie.pl.logger.chronicle.find(

--- a/Test/test_03.py
+++ b/Test/test_03.py
@@ -148,7 +148,7 @@ class Chronicles(unittest.TestCase):
         )
         self.assertEqual(7, len(entries))
         entries = dawgie.pl.logger.chronicle.find(
-            after=datetime(2017, 7, 1, tzinfo=UTC), status='failed'
+            after=datetime(2017, 7, 1, tzinfo=UTC), status='failure'
         )
         self.assertEqual(6, len(entries))
         entries = dawgie.pl.logger.chronicle.find(before=datetime.now(UTC))
@@ -163,7 +163,7 @@ class Chronicles(unittest.TestCase):
         entries = dawgie.pl.logger.chronicle.find(
             after=datetime(2017, 1, 1, tzinfo=UTC),
             before=datetime(2018, 1, 1, tzinfo=UTC),
-            status='failed',
+            status='failure',
         )
         self.assertEqual(14, len(entries))
         entries = dawgie.pl.logger.chronicle.find(


### PR DESCRIPTION
Closes #375 
Runnables can complete in 1 of 3 ways. The search of chronicles only covered sucess and failed. Added an endpoint to cover the invalid case. Updated the code behind the API to appropriately allow for multiple states.